### PR TITLE
Improve indentation of comments and preprocessor macros

### DIFF
--- a/src/com/intellij/plugins/haxe/ide/formatter/HaxeBlock.java
+++ b/src/com/intellij/plugins/haxe/ide/formatter/HaxeBlock.java
@@ -135,6 +135,12 @@ public class HaxeBlock extends AbstractBlock implements BlockWithParent {
     if (index == 0) {
       return new ChildAttributes(Indent.getNoneIndent(), null);
     }
+    if (prevType == HaxeTokenTypes.CONDITIONAL_STATEMENT_ID || prevType == HaxeTokenTypes.PPELSE || prevType == HaxeTokenTypes.PPEND || prevType == HaxeTokenTypes.PPELSEIF) {
+      return new ChildAttributes(Indent.getNormalIndent(), null);
+    }
+    if (prevType.toString().equals("MSL_COMMENT") || prevType.toString().equals("MML_COMMENT") || prevType.toString().equals("DOC_COMMENT")) {
+      return new ChildAttributes(Indent.getNormalIndent(), null);
+    }
     return new ChildAttributes(prev.getIndent(), prev.getAlignment());
   }
 


### PR DESCRIPTION
When typing comments and preprocessor macros and then pressing enter, the next line was not indented enough. It should have had the same indentation as the comment/macro but it was indented one tab less.
This change is fixing it to make the indentation of the following line the same as the previous comment/preprocessor macro.

Not sure if the code change is optimal but it works so far as expected.