### PR TITLE
Feature/haxe tests

### DIFF
--- a/common/src/com/intellij/plugins/haxe/config/HaxeTarget.java
+++ b/common/src/com/intellij/plugins/haxe/config/HaxeTarget.java
@@ -86,6 +86,10 @@ public enum HaxeTarget {
     this.description = description;
   }
 
+  public String getFlag() {
+    return flag;
+  }
+
   public String getCompilerFlag() {
     return "-" + flag;
   }

--- a/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
+++ b/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
@@ -252,8 +252,7 @@ public class HaxeCommonCompilerUtil {
     }
 
     commandLine.add(context.getHaxeTarget().getCompilerFlag());
-    String folder = settings.getOutputFolder() != null ? (settings.getOutputFolder() + "/") : "";
-    commandLine.add(folder + context.getOutputFileName());
+    commandLine.add(context.getOutputFileName());
   }
 
   private static void setupNME(List<String> commandLine, CompilationContext context) {

--- a/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
+++ b/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
@@ -53,6 +53,9 @@ public class HaxeCommonCompilerUtil {
 
     String getModuleName();
 
+    String getCompilationClass();
+    Boolean getIsTestBuild();
+
     void errorHandler(String message);
 
     void log(String message);
@@ -84,7 +87,7 @@ public class HaxeCommonCompilerUtil {
       context.log("Module " + context.getModuleName() + " is excluded from compilation.");
       return true;
     }
-    final String mainClass = settings.getMainClass();
+    final String mainClass = context.getCompilationClass();
     final String fileName = settings.getOutputFileName();
 
     if (settings.isUseUserPropertiesToBuild()) {
@@ -225,7 +228,7 @@ public class HaxeCommonCompilerUtil {
   private static void setupUserProperties(List<String> commandLine, CompilationContext context) {
     final HaxeModuleSettingsBase settings = context.getModuleSettings();
     commandLine.add("-main");
-    commandLine.add(settings.getMainClass());
+    commandLine.add(context.getCompilationClass());
 
     final StringTokenizer argumentsTokenizer = new StringTokenizer(settings.getArguments());
     while (argumentsTokenizer.hasMoreTokens()) {
@@ -246,7 +249,8 @@ public class HaxeCommonCompilerUtil {
     }
 
     commandLine.add(settings.getHaxeTarget().getCompilerFlag());
-    commandLine.add(settings.getOutputFileName());
+    String folder = settings.getOutputFolder() != null ? (settings.getOutputFolder() + "/") : "";
+    commandLine.add(folder + settings.getOutputFileName());
   }
 
   private static void setupNME(List<String> commandLine, CompilationContext context) {

--- a/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
+++ b/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
@@ -54,6 +54,7 @@ public class HaxeCommonCompilerUtil {
     String getModuleName();
 
     String getCompilationClass();
+    String getOutputFileName();
     Boolean getIsTestBuild();
 
     void errorHandler(String message);
@@ -78,6 +79,8 @@ public class HaxeCommonCompilerUtil {
 
     void handleOutput(String[] lines);
 
+    HaxeTarget getHaxeTarget();
+
     String getModuleDirPath();
   }
 
@@ -88,7 +91,7 @@ public class HaxeCommonCompilerUtil {
       return true;
     }
     final String mainClass = context.getCompilationClass();
-    final String fileName = settings.getOutputFileName();
+    final String fileName = context.getOutputFileName();
 
     if (settings.isUseUserPropertiesToBuild()) {
       if (mainClass == null || mainClass.length() == 0) {
@@ -101,7 +104,7 @@ public class HaxeCommonCompilerUtil {
       }
     }
 
-    final HaxeTarget target = settings.getHaxeTarget();
+    final HaxeTarget target = context.getHaxeTarget();
     final NMETarget nmeTarget = settings.getNmeTarget();
     final OpenFLTarget openFLTarget = settings.getOpenFLTarget();
 
@@ -167,7 +170,7 @@ public class HaxeCommonCompilerUtil {
       if (endIndex > 0) {
         workingPath = hxmlPath.substring(0, endIndex);
       }
-      if (context.isDebug() && settings.getHaxeTarget() == HaxeTarget.FLASH) {
+      if (context.isDebug() && context.getHaxeTarget() == HaxeTarget.FLASH) {
         commandLine.add("-D");
         commandLine.add("fdb");
         commandLine.add("-debug");
@@ -238,7 +241,7 @@ public class HaxeCommonCompilerUtil {
     if (context.isDebug()) {
       commandLine.add("-debug");
     }
-    if (settings.getHaxeTarget() == HaxeTarget.FLASH && context.isDebug()) {
+    if (context.getHaxeTarget() == HaxeTarget.FLASH && context.isDebug()) {
       commandLine.add("-D");
       commandLine.add("fdb");
     }
@@ -248,9 +251,9 @@ public class HaxeCommonCompilerUtil {
       commandLine.add(sourceRoot);
     }
 
-    commandLine.add(settings.getHaxeTarget().getCompilerFlag());
+    commandLine.add(context.getHaxeTarget().getCompilerFlag());
     String folder = settings.getOutputFolder() != null ? (settings.getOutputFolder() + "/") : "";
-    commandLine.add(folder + settings.getOutputFileName());
+    commandLine.add(folder + context.getOutputFileName());
   }
 
   private static void setupNME(List<String> commandLine, CompilationContext context) {

--- a/jps-plugin/src/org/jetbrains/jps/haxe/build/HaxeModuleLevelBuilder.java
+++ b/jps-plugin/src/org/jetbrains/jps/haxe/build/HaxeModuleLevelBuilder.java
@@ -134,6 +134,16 @@ public class HaxeModuleLevelBuilder extends ModuleLevelBuilder {
       }
 
       @Override
+      public String getCompilationClass() {
+        return getModuleSettings().getMainClass();
+      }
+
+      @Override
+      public Boolean getIsTestBuild() {
+        return false;
+      }
+
+      @Override
       public void errorHandler(String message) {
         context.processMessage(new CompilerMessage(BUILDER_NAME, BuildMessage.Kind.ERROR, message));
       }

--- a/jps-plugin/src/org/jetbrains/jps/haxe/build/HaxeModuleLevelBuilder.java
+++ b/jps-plugin/src/org/jetbrains/jps/haxe/build/HaxeModuleLevelBuilder.java
@@ -21,10 +21,12 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.plugins.haxe.HaxeCommonBundle;
 import com.intellij.plugins.haxe.compilation.HaxeCompilerError;
+import com.intellij.plugins.haxe.config.HaxeTarget;
 import com.intellij.plugins.haxe.module.HaxeModuleSettingsBase;
 import com.intellij.plugins.haxe.util.HaxeCommonCompilerUtil;
 import com.intellij.util.Function;
 import com.intellij.util.containers.ContainerUtil;
+import org.apache.velocity.texen.util.FileUtil;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -139,6 +141,11 @@ public class HaxeModuleLevelBuilder extends ModuleLevelBuilder {
       }
 
       @Override
+      public String getOutputFileName() {
+        return getModuleSettings().getOutputFileName();
+      }
+
+      @Override
       public Boolean getIsTestBuild() {
         return false;
       }
@@ -213,6 +220,11 @@ public class HaxeModuleLevelBuilder extends ModuleLevelBuilder {
             compilerError != null ? (long)compilerError.getColumn() : -1L
           ));
         }*/
+      }
+
+      @Override
+      public HaxeTarget getHaxeTarget() {
+        return getModuleSettings().getHaxeTarget();
       }
 
       @Override

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -252,6 +252,7 @@
     <!-- HXML END -->
 
     <programRunner implementation="com.intellij.plugins.haxe.runner.HaxeRunner"/>
+    <programRunner implementation="com.intellij.plugins.haxe.tests.runner.HaxeTestsRunner"/>
 
     <lang.parserDefinition language="Haxe" implementationClass="com.intellij.plugins.haxe.lang.parser.HaxeParserDefinition"/>
     <lang.formatter language="Haxe" implementationClass="com.intellij.plugins.haxe.ide.formatter.HaxeFormattingModelBuilder"/>
@@ -310,6 +311,7 @@
     <completion.contributor language="HXML" implementationClass="com.intellij.plugins.haxe.ide.HXMLCompilerArgumentsCompletionContributor"/>
 
     <configurationType implementation="com.intellij.plugins.haxe.runner.HaxeRunConfigurationType"/>
+    <configurationType implementation="com.intellij.plugins.haxe.tests.runner.HaxeTestsRunConfigurationType"/>
 
     <moduleService serviceInterface="com.intellij.plugins.haxe.ide.module.HaxeModuleSettings"
                    serviceImplementation="com.intellij.plugins.haxe.ide.module.HaxeModuleSettings"/>

--- a/src/com/intellij/plugins/haxe/HaxeBundle.properties
+++ b/src/com/intellij/plugins/haxe/HaxeBundle.properties
@@ -146,3 +146,9 @@ haxe.openfl.xmlproject=OpenFL Project XML \:
 hxml.language.id = HXML
 hxml.file.type.name = HXML
 hxml.file.type.description = Haxe Build Files
+
+# HAXE tests
+
+haxe.tests.runner.configuration.name=Haxe Tests
+haxe.tests.run.module=&Module\:
+haxe.tests.run.runner.class=&Runner Class\:

--- a/src/com/intellij/plugins/haxe/compilation/HaxeCompiler.java
+++ b/src/com/intellij/plugins/haxe/compilation/HaxeCompiler.java
@@ -32,9 +32,11 @@ import com.intellij.openapi.projectRoots.SdkAdditionalData;
 import com.intellij.openapi.roots.CompilerModuleExtension;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.OrderEnumerator;
+import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.plugins.haxe.HaxeBundle;
+import com.intellij.plugins.haxe.config.HaxeTarget;
 import com.intellij.plugins.haxe.config.sdk.HaxeSdkAdditionalDataBase;
 import com.intellij.plugins.haxe.ide.module.HaxeModuleSettings;
 import com.intellij.plugins.haxe.ide.module.HaxeModuleType;
@@ -219,6 +221,11 @@ public class HaxeCompiler implements SourceProcessingCompiler {
       }
 
       @Override
+      public String getOutputFileName() {
+        return getFileNameWithCurrentExtension(getModuleSettings().getOutputFileName());
+      }
+
+      @Override
       public Boolean getIsTestBuild() {
         return finalHaxeTestsConfiguration != null;
       }
@@ -286,6 +293,19 @@ public class HaxeCompiler implements SourceProcessingCompiler {
       @Override
       public void handleOutput(String[] lines) {
         HaxeCompilerUtil.fillContext(context, getErrorRoot(), lines);
+      }
+
+      @Override
+      public HaxeTarget getHaxeTarget() {
+        //actually only neko target is supported for tests
+        return getIsTestBuild() ? HaxeTarget.NEKO : getModuleSettings().getHaxeTarget();
+      }
+
+      private String getFileNameWithCurrentExtension(String fileName) {
+        if (getHaxeTarget() != null) {
+          return getHaxeTarget().getTargetFileNameWithExtension(FileUtil.getNameWithoutExtension(fileName));
+        }
+        return fileName;
       }
 
       @Override

--- a/src/com/intellij/plugins/haxe/tests/runner/HaxeTestsConfiguration.java
+++ b/src/com/intellij/plugins/haxe/tests/runner/HaxeTestsConfiguration.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2015 AS3Boyan
+ * Copyright 2014-2015 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.tests.runner;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.Executor;
+import com.intellij.execution.configuration.EmptyRunProfileState;
+import com.intellij.execution.configurations.*;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.runners.RunConfigurationWithSuppressedDefaultRunAction;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.InvalidDataException;
+import com.intellij.openapi.util.WriteExternalException;
+import com.intellij.plugins.haxe.runner.HaxeApplicationModuleBasedConfiguration;
+import com.intellij.plugins.haxe.tests.runner.ui.HaxeTestConfigurationEditorForm;
+import com.intellij.util.xmlb.XmlSerializer;
+import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public class HaxeTestsConfiguration extends ModuleBasedConfiguration<HaxeApplicationModuleBasedConfiguration>
+  implements RunConfigurationWithSuppressedDefaultRunAction {
+
+  private String myRunnerClass;
+
+  public HaxeTestsConfiguration(String name,
+                                Project configurationModule,
+                                HaxeTestsRunConfigurationType configurationType) {
+    super(name, new HaxeApplicationModuleBasedConfiguration(configurationModule), configurationType.getConfigurationFactories()[0]);
+  }
+
+  @Override
+  public Collection<Module> getValidModules() {
+    Module[] modules = ModuleManager.getInstance(getProject()).getModules();
+    return Arrays.asList(modules);
+  }
+
+  @NotNull
+  @Override
+  public SettingsEditor<? extends RunConfiguration> getConfigurationEditor() {
+    return new HaxeTestConfigurationEditorForm(getProject());
+  }
+
+  @Nullable
+  @Override
+  public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) throws ExecutionException {
+    return EmptyRunProfileState.INSTANCE;
+  }
+
+  public void writeExternal(final Element element) throws WriteExternalException {
+    super.writeExternal(element);
+    writeModule(element);
+    XmlSerializer.serializeInto(this, element);
+  }
+
+  public void readExternal(final Element element) throws InvalidDataException {
+    super.readExternal(element);
+    readModule(element);
+    XmlSerializer.deserializeInto(this, element);
+  }
+
+  public String getRunnerClass() {
+    return myRunnerClass;
+  }
+
+  public void setRunnerClass(String runnerClass) {
+    myRunnerClass = runnerClass;
+  }
+}

--- a/src/com/intellij/plugins/haxe/tests/runner/HaxeTestsRunConfigurationType.java
+++ b/src/com/intellij/plugins/haxe/tests/runner/HaxeTestsRunConfigurationType.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2015 AS3Boyan
+ * Copyright 2014-2015 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.tests.runner;
+
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.ConfigurationType;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.openapi.project.Project;
+import com.intellij.plugins.haxe.HaxeBundle;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class HaxeTestsRunConfigurationType implements ConfigurationType {
+
+  private final HaxeTestsFactory configurationFactory;
+
+  public HaxeTestsRunConfigurationType() {
+    configurationFactory = new HaxeTestsFactory(this);
+  }
+
+  @Override
+  public String getDisplayName() {
+    return HaxeBundle.message("haxe.tests.runner.configuration.name");
+  }
+
+  @Override
+  public String getConfigurationTypeDescription() {
+    return HaxeBundle.message("haxe.tests.runner.configuration.name");
+  }
+
+  @Override
+  public Icon getIcon() {
+    return icons.HaxeIcons.Haxe_16;
+  }
+
+  @NotNull
+  @Override
+  public String getId() {
+    return "HaxeTestsRunConfiguration";
+  }
+
+  @Override
+  public ConfigurationFactory[] getConfigurationFactories() {
+    return new ConfigurationFactory[]{configurationFactory};
+  }
+
+  public static class HaxeTestsFactory extends ConfigurationFactory {
+
+    private HaxeTestsRunConfigurationType configurationType;
+
+    public HaxeTestsFactory(ConfigurationType type) {
+      super(type);
+      configurationType = (HaxeTestsRunConfigurationType)type;
+    }
+
+    public RunConfiguration createTemplateConfiguration(Project project) {
+      final String name = HaxeBundle.message("runner.configuration.name");
+      return new HaxeTestsConfiguration(name, project, configurationType);
+    }
+  }
+}

--- a/src/com/intellij/plugins/haxe/tests/runner/HaxeTestsRunner.java
+++ b/src/com/intellij/plugins/haxe/tests/runner/HaxeTestsRunner.java
@@ -81,7 +81,7 @@ public class HaxeTestsRunner extends DefaultProgramRunner {
         commandLine.addParameter(getFileNameWithCurrentExtension(currentTarget, folder + settings.getOutputFileName()));
 
         final TextConsoleBuilder consoleBuilder = TextConsoleBuilderFactory.getInstance().createBuilder(module.getProject());
-        consoleBuilder.addFilter(new ErrorFilter(module.getProject()));
+        consoleBuilder.addFilter(new ErrorFilter(module));
         setConsoleBuilder(consoleBuilder);
 
         return new OSProcessHandler(commandLine.createProcess(), commandLine.getCommandLineString());

--- a/src/com/intellij/plugins/haxe/tests/runner/HaxeTestsRunner.java
+++ b/src/com/intellij/plugins/haxe/tests/runner/HaxeTestsRunner.java
@@ -77,7 +77,7 @@ public class HaxeTestsRunner extends DefaultProgramRunner {
         commandLine.setWorkDirectory(PathUtil.getParentPath(module.getModuleFilePath()));
         commandLine.setExePath(currentTarget.getFlag());
         final HaxeModuleSettings settings = HaxeModuleSettings.getInstance(module);
-        String folder = settings.getOutputFolder() != null ? (settings.getOutputFolder() + "/") : "";
+        String folder = settings.getOutputFolder() != null ? (settings.getOutputFolder() + "/release/") : "";
         commandLine.addParameter(getFileNameWithCurrentExtension(currentTarget, folder + settings.getOutputFileName()));
 
         final TextConsoleBuilder consoleBuilder = TextConsoleBuilderFactory.getInstance().createBuilder(module.getProject());

--- a/src/com/intellij/plugins/haxe/tests/runner/HaxeTestsRunner.java
+++ b/src/com/intellij/plugins/haxe/tests/runner/HaxeTestsRunner.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2015 AS3Boyan
+ * Copyright 2014-2015 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.tests.runner;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.CommandLineState;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.configurations.RunProfile;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.executors.DefaultRunExecutor;
+import com.intellij.execution.filters.TextConsoleBuilder;
+import com.intellij.execution.filters.TextConsoleBuilderFactory;
+import com.intellij.execution.process.*;
+import com.intellij.execution.runners.DefaultProgramRunner;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.ui.RunContentDescriptor;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.plugins.haxe.ide.module.HaxeModuleSettings;
+import com.intellij.util.PathUtil;
+import org.jetbrains.annotations.NotNull;
+import java.util.List;
+
+public class HaxeTestsRunner extends DefaultProgramRunner {
+
+  public static final String HAXE_TESTS_RUNNER_ID = "HaxeTestsRunner";
+
+  @NotNull
+  @Override
+  public String getRunnerId() {
+    return HAXE_TESTS_RUNNER_ID;
+  }
+
+  @Override
+  public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
+    return DefaultRunExecutor.EXECUTOR_ID.equals(executorId) && profile instanceof HaxeTestsConfiguration;
+  }
+
+  @Override
+  protected RunContentDescriptor doExecute(@NotNull final Project project,
+                                           @NotNull RunProfileState state,
+                                           final RunContentDescriptor descriptor,
+                                           @NotNull final ExecutionEnvironment environment) throws ExecutionException {
+
+    final HaxeTestsConfiguration profile = (HaxeTestsConfiguration)environment.getRunProfile();
+    final Module module = profile.getConfigurationModule().getModule();
+
+    ModuleRootManager rootManager = ModuleRootManager.getInstance(module);
+    VirtualFile[] roots = rootManager.getContentRoots();
+
+    return super.doExecute(project, new CommandLineState(environment) {
+      @NotNull
+      @Override
+      protected ProcessHandler startProcess() throws ExecutionException {
+        final GeneralCommandLine commandLine = new GeneralCommandLine();
+        commandLine.setWorkDirectory(PathUtil.getParentPath(module.getModuleFilePath()));
+        commandLine.setExePath("neko");
+        final HaxeModuleSettings settings = HaxeModuleSettings.getInstance(module);
+        String folder = settings.getOutputFolder() != null ? (settings.getOutputFolder() + "/") : "";
+        commandLine.addParameter(folder + settings.getOutputFileName());
+
+        final TextConsoleBuilder consoleBuilder = TextConsoleBuilderFactory.getInstance().createBuilder(module.getProject());
+        setConsoleBuilder(consoleBuilder);
+
+        return new OSProcessHandler(commandLine.createProcess(), commandLine.getCommandLineString());
+      }
+    }, descriptor, environment);
+  }
+}

--- a/src/com/intellij/plugins/haxe/tests/runner/filters/ErrorFilter.java
+++ b/src/com/intellij/plugins/haxe/tests/runner/filters/ErrorFilter.java
@@ -73,6 +73,6 @@ public class ErrorFilter implements Filter {
         break;
       }
     }
-    return virtualFile == null ? null : new OpenFileHyperlinkInfo(myModule.getProject(), virtualFile, line);
+    return virtualFile == null ? null : new OpenFileHyperlinkInfo(myModule.getProject(), virtualFile, line - 1);
   }
 }

--- a/src/com/intellij/plugins/haxe/tests/runner/filters/ErrorFilter.java
+++ b/src/com/intellij/plugins/haxe/tests/runner/filters/ErrorFilter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2015 AS3Boyan
+ * Copyright 2014-2015 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.tests.runner.filters;
+
+import com.intellij.execution.filters.Filter;
+import com.intellij.execution.filters.HyperlinkInfo;
+import com.intellij.execution.filters.OpenFileHyperlinkInfo;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.Nullable;
+
+public class ErrorFilter implements Filter {
+
+  private Project myProject;
+
+  private final String START_TOKEN = "ERR: ";
+
+  public ErrorFilter(Project project) {
+    myProject = project;
+  }
+
+  @Nullable
+  @Override
+  public Result applyFilter(String s, int i) {
+    if(s.indexOf(START_TOKEN) == -1) {
+      return null;
+    }
+    int classAndLineIndex = START_TOKEN.length();
+    int openBraceIndex = s.indexOf("(");
+    int closeBraceIndex = s.indexOf(")");
+
+    String classAndLine = s.substring(classAndLineIndex, openBraceIndex);
+    Integer lineNumber = Integer.parseInt(classAndLine.substring(classAndLine.indexOf(":") + 1));
+
+    String classAndFunction = s.substring(openBraceIndex + 1, closeBraceIndex).replace(".", "/");
+    String functionName = classAndFunction.substring(classAndFunction.lastIndexOf("/") + 1);
+    HyperlinkInfo hyperlink = createOpenFileHyperlink(classAndFunction.replace("/" + functionName, ".hx"), lineNumber);
+    return new Result(i - s.length() + classAndLineIndex, i - s.length() + openBraceIndex, hyperlink);
+  }
+
+  protected HyperlinkInfo createOpenFileHyperlink(String filePath, int line) {
+    String fullPath = "/Users/vaukalak/Documents/work/projects/farm/iso-model/test/" + filePath;
+    VirtualFile virtualFile = LocalFileSystem.getInstance().findFileByPath(fullPath);
+    return new OpenFileHyperlinkInfo(myProject, virtualFile, line);
+  }
+}

--- a/src/com/intellij/plugins/haxe/tests/runner/ui/HaxeTestConfigurationEditorForm.form
+++ b/src/com/intellij/plugins/haxe/tests/runner/ui/HaxeTestConfigurationEditorForm.form
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.intellij.plugins.haxe.tests.runner.ui.HaxeTestConfigurationEditorForm">
+  <grid id="27dc6" binding="component" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="241"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <grid id="7f0c3" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="36bd4" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <labelFor value="70531"/>
+              <text resource-bundle="com/intellij/plugins/haxe/HaxeBundle" key="haxe.tests.run.module"/>
+            </properties>
+          </component>
+          <component id="897c8" class="javax.swing.JComboBox" binding="myComboModules">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <minimum-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+          <hspacer id="5dbb7">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+        </children>
+      </grid>
+      <vspacer id="7d359">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <grid id="fdeae" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="85519" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <labelFor value="70531"/>
+              <text resource-bundle="com/intellij/plugins/haxe/HaxeBundle" key="haxe.tests.run.runner.class"/>
+            </properties>
+          </component>
+          <component id="aa2b0" class="javax.swing.JComboBox" binding="myComboRunnerClasses">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <minimum-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+          <hspacer id="d7aad">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+        </children>
+      </grid>
+    </children>
+  </grid>
+</form>

--- a/src/com/intellij/plugins/haxe/tests/runner/ui/HaxeTestConfigurationEditorForm.java
+++ b/src/com/intellij/plugins/haxe/tests/runner/ui/HaxeTestConfigurationEditorForm.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2015 AS3Boyan
+ * Copyright 2014-2015 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.tests.runner.ui;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.plugins.haxe.config.HaxeTarget;
+import com.intellij.plugins.haxe.config.NMETarget;
+import com.intellij.plugins.haxe.config.OpenFLTarget;
+import com.intellij.plugins.haxe.ide.module.HaxeModuleType;
+import com.intellij.plugins.haxe.lang.psi.HaxeClass;
+import com.intellij.plugins.haxe.tests.runner.HaxeTestsConfiguration;
+import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
+import com.intellij.ui.ListCellRendererWrapper;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.jps.model.java.JavaSourceRootType;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HaxeTestConfigurationEditorForm extends SettingsEditor<HaxeTestsConfiguration> {
+  private JComboBox myComboModules;
+  private JComboBox myComboRunnerClasses;
+  private JPanel component;
+
+  public HaxeTestConfigurationEditorForm(Project project) {
+  }
+
+  @Override
+  protected void resetEditorFrom(final HaxeTestsConfiguration configuration) {
+
+    //init modules
+
+    myComboModules.removeAllItems();
+
+    final Module[] modules = ModuleManager.getInstance(configuration.getProject()).getModules();
+    for (final Module module : modules) {
+      if (ModuleType.get(module) == HaxeModuleType.getInstance()) {
+        myComboModules.addItem(module);
+      }
+    }
+    myComboModules.setSelectedItem(configuration.getConfigurationModule().getModule());
+    myComboModules.addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        updateModule((Module)myComboModules.getSelectedItem());
+        myComboRunnerClasses.setSelectedIndex(-1);
+      }
+    });
+
+    //init runner
+
+    myComboRunnerClasses.setSelectedItem(configuration.getRunnerClass());
+    myComboRunnerClasses.addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        HaxeClass item = (HaxeClass)myComboRunnerClasses.getSelectedItem();
+        if(item != null) {
+          configuration.setRunnerClass(item.getName());
+        }
+      }
+    });
+
+    myComboRunnerClasses.setRenderer(new ListCellRendererWrapper() {
+      @Override
+      public void customize(JList list, Object value, int index, boolean selected, boolean hasFocus) {
+        if (value instanceof HaxeClass) {
+          final HaxeClass haxeClass = (HaxeClass)value;
+          setText(haxeClass.getName());
+        }
+      }
+    });
+
+    //
+
+    updateModule((Module)myComboModules.getSelectedItem());
+  }
+
+  private void updateModule(Module module) {
+    if (module == null) {
+        return;
+    }
+    myComboRunnerClasses.removeAllItems();
+
+    ModuleRootManager rootManager = ModuleRootManager.getInstance(module);
+
+    List<VirtualFile> roots = rootManager.getSourceRoots(JavaSourceRootType.TEST_SOURCE);
+    List<HaxeClass> classList = new ArrayList<HaxeClass>();
+    for (VirtualFile testSourceRoot : roots) {
+      classList.addAll(UsefulPsiTreeUtil.getClassesInDirectory(module.getProject(), testSourceRoot));
+    }
+    classList.size();
+    for (HaxeClass haxeClass : classList) {
+      myComboRunnerClasses.addItem(haxeClass);
+    }
+  }
+
+  @Override
+  protected void applyEditorTo(HaxeTestsConfiguration configuration) throws ConfigurationException {
+    configuration.setModule(getSelectedModule());
+  }
+
+  private Module getSelectedModule() {
+    return (Module)myComboModules.getSelectedItem();
+  }
+
+  @NotNull
+  @Override
+  protected JComponent createEditor() {
+    return component;
+  }
+}

--- a/src/com/intellij/plugins/haxe/util/UsefulPsiTreeUtil.java
+++ b/src/com/intellij/plugins/haxe/util/UsefulPsiTreeUtil.java
@@ -21,7 +21,6 @@ import com.intellij.lang.ASTNode;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.PackageIndex;
 import com.intellij.openapi.util.Condition;
-import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.plugins.haxe.HaxeFileType;
 import com.intellij.plugins.haxe.lang.psi.*;
@@ -171,25 +170,35 @@ public class UsefulPsiTreeUtil {
     Project project = importStatementWithWildcard.getProject();
     VirtualFile[] virtualDirectoriesForPackage = getVirtualDirectoriesForPackage(packageStatement, project);
     for (VirtualFile file : virtualDirectoriesForPackage) {
-      VirtualFile[] files = file.getChildren();
-      for (VirtualFile virtualFile : files) {
-        if (virtualFile.getFileType().equals(HaxeFileType.HAXE_FILE_TYPE)) {
-          PsiFile psiFile = PsiManager.getInstance(project).findFile(virtualFile);
+      populateClassesList(classList, project, file);
+    }
+    return classList;
+  }
 
-          String nameWithoutExtension = virtualFile.getNameWithoutExtension();
+  private static void populateClassesList(List<HaxeClass> classList, Project project, VirtualFile file) {
+    VirtualFile[] files = file.getChildren();
+    for (VirtualFile virtualFile : files) {
+      if (virtualFile.getFileType().equals(HaxeFileType.HAXE_FILE_TYPE)) {
+        PsiFile psiFile = PsiManager.getInstance(project).findFile(virtualFile);
 
-          List<HaxeClass> haxeClassList = HaxeResolveUtil.findComponentDeclarations(psiFile);
-          for (HaxeClass haxeClass : haxeClassList) {
-            if (haxeClass.getName().equals(nameWithoutExtension)) {
-              classList.add(haxeClass);
-            }
+        String nameWithoutExtension = virtualFile.getNameWithoutExtension();
+
+        List<HaxeClass> haxeClassList = HaxeResolveUtil.findComponentDeclarations(psiFile);
+        for (HaxeClass haxeClass : haxeClassList) {
+          if (haxeClass.getName().equals(nameWithoutExtension)) {
+            classList.add(haxeClass);
           }
         }
       }
     }
+  }
+
+  public static List<HaxeClass> getClassesInDirectory(Project project, VirtualFile file) {
+    List<HaxeClass> classList = new ArrayList<HaxeClass>();
+    populateClassesList(classList, project, file);
     return classList;
   }
-  
+
   @NotNull
   public static boolean importStatementWithWildcardForClassName(HaxeImportStatementWithWildcard importStatementWithWildcard, String classname) {
     if (!Character.isUpperCase(classname.charAt(0))) {

--- a/testSrc/com/intellij/plugins/haxe/tests/filters/ErrorFilterTest.java
+++ b/testSrc/com/intellij/plugins/haxe/tests/filters/ErrorFilterTest.java
@@ -38,7 +38,8 @@ public class ErrorFilterTest {
     assertEquals("ERR: ".length(), result.highlightStartOffset);
     assertEquals("ERR: CoordinatesDetectionTest.hx:22".length(), result.highlightEndOffset);
     HLInfo info = (HLInfo) result.hyperlinkInfo;
-    info.checkInfo(fileName, 22);
+    //idea count lines starting from 0
+    info.checkInfo(fileName, 22 - 1);
 
 
   }

--- a/testSrc/com/intellij/plugins/haxe/tests/filters/ErrorFilterTest.java
+++ b/testSrc/com/intellij/plugins/haxe/tests/filters/ErrorFilterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2015 AS3Boyan
+ * Copyright 2014-2015 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.tests.filters;
+
+import com.intellij.execution.filters.Filter;
+import com.intellij.execution.filters.HyperlinkInfo;
+import com.intellij.execution.filters.RegexpFilter;
+import com.intellij.openapi.project.Project;
+import com.intellij.plugins.haxe.tests.runner.filters.ErrorFilter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ErrorFilterTest {
+
+  @Test
+  public void testLink() {
+    String expression = "ERR: CoordinatesDetectionTest.hx:22(by.rovar.iso.model.CoordinatesDetectionTest.test2x2) - expected true but was false";
+    ErrorFilter filter = createFilter();
+    String fileName = "by/rovar/iso/model/CoordinatesDetectionTest.hx";
+    Filter.Result result = filter.applyFilter(expression, expression.length());
+    assertEquals("ERR: ".length(), result.highlightStartOffset);
+    assertEquals("ERR: CoordinatesDetectionTest.hx:22".length(), result.highlightEndOffset);
+    HLInfo info = (HLInfo) result.hyperlinkInfo;
+    info.checkInfo(fileName, 22);
+
+
+  }
+
+  private ErrorFilter createFilter() {
+    return new ErrorFilter(null){
+      @Override
+      protected HyperlinkInfo createOpenFileHyperlink(String filePath, int line) {
+        return createOpenFile(filePath, line);
+      }
+    };
+  }
+
+  private static HyperlinkInfo createOpenFile(String fileName, int line) {
+    return new HLInfo(fileName, line);
+  }
+
+  private static class HLInfo implements HyperlinkInfo {
+    public String myFileName;
+    public int myLine;
+
+    public HLInfo(String fileName, int line) {
+      myFileName = fileName;
+      myLine = line;
+    }
+
+    @Override
+    public void navigate(Project project) {
+    }
+
+    public void checkInfo(String fileName, int line) {
+      assertEquals(fileName, myFileName);
+      assertEquals(line, myLine);
+    }
+  }
+}


### PR DESCRIPTION
This patch gives possibility to launch haxe tests. Actually there a limitation: only Neko target is available (module target is overridden when compiling with tests configuration). In configuration user can select module and runner class.