### PR TITLE
Add cli test build and run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+- openjdk7
+- oraclejdk7
+script: ./travis.sh

--- a/build-test.xml
+++ b/build-test.xml
@@ -1,0 +1,136 @@
+<project name="Idea Haxe language scripted test file" default="test" basedir=".">
+
+    <!-- set global properties for this build -->
+    <property name="build.compiler" value="modern"/>
+    <property name="idea.ultimate.build" location="${basedir}/idea-IU/" />
+
+    <path id="idea.classpath">
+        <fileset dir="${idea.ultimate.build}/lib">
+            <include name="*.jar"/>
+        </fileset>
+        <!-- import all the plugins jars, for example this is were
+             Flash and Flex plugins are located -->
+        <fileset dir="${idea.ultimate.build}/plugins">
+            <include name="**/**.jar"/>
+        </fileset>
+    </path>
+
+    <path id="classpath">
+        <path refid="idea.classpath"/>
+    </path>
+
+    <path id="classpath.test">
+        <pathelement location="build_test"/>
+        <fileset dir="${idea.ultimate.build}/lib">
+            <include name="**/*.jar" />
+            <exclude name="ant/lib/**/*.jar" />
+        </fileset>
+        <fileset dir="${java.home}/../lib">
+            <include name="**/*.jar" />
+        </fileset>
+        <fileset dir="${idea.ultimate.build}/plugins">
+            <include name="**/**.jar" />
+        </fileset>
+    </path>
+
+    <target name="clean" description="clean up">
+        <delete dir="build_test" />
+    </target>
+
+    <target name="init">
+        <tstamp/>
+        <mkdir dir="build_test"/>
+        <echo message="Using IDEA build from: ${idea.ultimate.build}" />
+        <echo message="Using JAVA_HOME: ${java.home}" />
+    </target>
+
+    <target name="compile_test" depends="clean,init" description="Compile tests">
+
+        <!-- javac2 is an intellij ant task to wrap the java compiler and add
+             support to .form files and @NotNull annotations, among others -->
+        <taskdef name="javac2" classname="com.intellij.ant.Javac2">
+            <classpath>
+                <pathelement location="${idea.ultimate.build}/lib/javac2.jar"/>
+                <pathelement location="${idea.ultimate.build}/lib/forms_rt.jar"/>
+                <path refid="idea.classpath"/>
+            </classpath>
+        </taskdef>
+
+        <javac2
+            destdir="build_test"
+            classpathref="classpath"
+            verbose="false"
+            debug="true"
+            source="1.6"
+            target="1.6"
+            includeantruntime="false" >
+
+            <src path="src" />
+            <src path="gen" />
+            <src path="testSrc" />
+            <src path="testData" />
+            <src path="common/src" />
+            <src path="hxcpp-debugger-protocol" />
+        </javac2>
+
+        <copy toDir="build_test">
+            <fileset dir="src">
+                <include name="**/*.properties"/>
+                <include name="**/*.xml"/>
+                <include name="**/*.txt"/>
+                <include name="**/*.java"/>
+            </fileset>
+            <fileset dir="common/src">
+                <include name="**/*.properties"/>
+                <include name="**/*.xml"/>
+                <include name="**/*.txt"/>
+                <include name="**/*.java"/>
+            </fileset>
+            <fileset dir="${basedir}/resources">
+                <include name="*/**"/>
+            </fileset>
+        </copy>
+
+    </target>
+
+    <target name="test" depends="compile_test" description="Run the tests">
+
+        <echo message="Running tests"/>
+
+        <property name="suspend" value="n"/>
+
+        <junit
+            printsummary="yes"
+            haltonfailure="true"
+            showoutput="yes"
+            failureProperty="failure_found"
+            fork="yes"
+            forkmode="once"
+            reloading="no">
+
+            <jvmarg value="-Didea.home.path=${idea.ultimate.build}"/>
+            <jvmarg value="-Xbootclasspath/a:${idea.ultimate.build}/lib/boot.jar"/>
+            <jvmarg value="-Dfile.encoding=UTF-8"/>
+            <jvmarg value="-ea"/>
+            <jvmarg line="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=${suspend},address=43251"/>
+            <jvmarg value="-Didea.launcher.bin.path=${idea.ultimate.build}/bin"/>
+            <classpath refid="classpath.test"/>
+
+            <formatter type="brief" usefile="false"/>
+
+            <batchtest>
+                <fileset dir="testSrc">
+                    <include name="**/*Test.java"/>
+                    <exclude name="**/*TestCase.java"/>
+                </fileset>
+            </batchtest>
+        </junit>
+
+        <antcall target="check_test"/>
+    </target>
+
+    <target name="check_test" if="failure_found">
+        <fail message="Failures found"/>
+    </target>
+
+</project>

--- a/fetchIdea.sh
+++ b/fetchIdea.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+ideaVersion="13.1.6"
+
+if [ ! -d ./idea-IU ]; then
+    # Get our IDEA dependency
+    if [ -f ~/Tools/ideaIU-${ideaVersion}.tar.gz ];
+    then
+        cp ~/Tools/ideaIU-${ideaVersion}.tar.gz .
+    else
+        wget http://download.jetbrains.com/idea/ideaIU-${ideaVersion}.tar.gz && mkdir -p ~/Tools && cp ideaIU-${ideaVersion}.tar.gz ~/Tools/ideaIU-${ideaVersion}.tar.gz
+    fi
+
+    # Unzip IDEA
+    tar zxf ideaIU-${ideaVersion}.tar.gz
+    rm -rf ideaIU-${ideaVersion}.tar.gz
+
+    # Move the versioned IDEA folder to a known location
+    ideaPath=$(find . -name 'idea-IU*' | head -n 1)
+    mv ${ideaPath} ./idea-IU
+fi

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+./fetchIdea.sh
+
+# Run the tests
+if [ "$1" = "-d" ]; then
+    ant -d -f build-test.xml -DIDEA_HOME=./idea-IU
+else
+    ant -f build-test.xml -DIDEA_HOME=./idea-IU
+fi
+
+# Was our build successful?
+stat=$?
+
+if [ "${TRAVIS}" != true ]; then
+    ant -f build-test.xml -q clean
+    rm -rf idea-IU
+fi
+
+# Return the build status
+exit ${stat}


### PR DESCRIPTION
This uses Ant and a couple shell scripts. You need Ant and oracle jdk installed to run the it, I'll document all of this in the readme. The .travis.yml file takes care of installing build dependencies for Travis.ci.
Locally, you can run ./travis.sh to build and run the tests.

notes:
- We might want to get rid of the shell script eventually and use Ant to fetch the idea sdk in order to make it work on Windows.
- I tried to remove all unecessary cruft from the Ant file, which is already pretty busy for just running tests. Someone with better knowledge of Ant might be able to simplify this.