### PR TITLE
Ant script to automate plugin jar build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./fetchIdea.sh
+
+ant -f build.xml -DIDEA_HOME=./idea-IU

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,62 @@
+<project name="Idea Haxe language scripted package plugin" default="package" basedir=".">
+
+    <!-- set global properties for this build -->
+    <property name="build.compiler" value="modern"/>
+    <property name="idea.ultimate.build" location="${basedir}/idea-IU/" />
+
+    <!-- javac2 is an intellij ant task to wrap the java compiler and add
+         support to .form files and @NotNull annotations, among others -->
+    <taskdef name="javac2" classname="com.intellij.ant.Javac2">
+        <classpath>
+            <pathelement location="${idea.ultimate.build}/lib/javac2.jar"/>
+            <pathelement location="${idea.ultimate.build}/lib/forms_rt.jar"/>
+            <pathelement location="${idea.ultimate.build}/lib/asm-all.jar"/>
+            <fileset dir="${idea.ultimate.build}/lib" includes="**/*.jar" />
+            <fileset dir="${idea.ultimate.build}/plugins" includes="**/**.jar" />
+        </classpath>
+    </taskdef>
+
+    <target name="clean" description="clean up">
+        <delete dir="build" />
+    </target>
+
+    <target name="init">
+        <tstamp/>
+        <mkdir dir="build"/>
+        <echo message="Using IDEA build from: ${idea.ultimate.build}" />
+        <echo message="Using JAVA_HOME: ${java.home}" />
+    </target>
+
+    <target name="compile_test" depends="clean,init" description="Compile tests">
+
+        <javac2
+            destdir="build"
+            verbose="false"
+            debug="true"
+            source="1.6"
+            target="1.6"
+            includeantruntime="false" >
+
+            <src path="src" />
+            <src path="gen" />
+            <src path="common/src" />
+            <src path="hxcpp-debugger-protocol" />
+            <classpath>
+                <fileset dir="${idea.ultimate.build}/lib" includes="**/*.jar" />
+                <fileset dir="${idea.ultimate.build}/plugins" includes="**/**.jar" />
+            </classpath>
+        </javac2>
+
+    </target>
+
+    <target name="package" depends="compile_test" description="generate jar file">
+        <jar jarfile="intellij-haxe.jar" update="true">
+            <fileset dir="build" includes="**/*.*" />
+            <fileset dir="src" excludes="**/*.java" />
+            <fileset dir="resources" />
+        </jar>
+
+    </target>
+
+</project>
+


### PR DESCRIPTION
Generates the same intellij-haxe.jar than with Intellij IDEA.rbos
I've tried the generated plugin and it seemed to work well.

I might revisit the choice of shell script + Ant at some point, this seems verbose for such simple build tasks and it makes it hard to build on Windows.