### PR TITLE
added script to build haxe and hxml parsers using GrammarKit

### DIFF
--- a/build-parsers.sh
+++ b/build-parsers.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+GrammarKitVersion="1.2.0"
+
+if [ ! -d ./GrammarKit/ ]; then
+    # Get our GrammarKit dependency
+    if [ -f ~/Tools/GrammarKit-${GrammarKitVersion}.zip ];
+    then
+        cp ~/Tools/GrammarKit-${GrammarKitVersion}.zip . &&
+        cp ~/Tools/light-psi-all-${GrammarKitVersion}.jar .
+    else
+        `wget -O GrammarKit-${GrammarKitVersion}.zip https://github.com/JetBrains/Grammar-Kit/releases/download/${GrammarKitVersion}/GrammarKit.zip`&&
+        `wget -O light-psi-all-${GrammarKitVersion}.jar https://github.com/JetBrains/Grammar-Kit/releases/download/${GrammarKitVersion}/light-psi-all.jar` &&
+
+        #Cache file locally except for Travis build which creates a new VM every time
+        if [ "${TRAVIS}" != true ]; then
+            mkdir -p ~/Tools &&
+            cp GrammarKit-${GrammarKitVersion}.zip ~/Tools/ &&
+            cp light-psi-all-${GrammarKitVersion}.jar ~/Tools/
+        fi
+    fi
+
+    # Unzip GrammarKit
+    unzip GrammarKit-${GrammarKitVersion}.zip
+    mv GrammarKit/lib/grammar-kit.jar .
+    mv light-psi-all-${GrammarKitVersion}.jar light-psi-all.jar
+fi
+
+#Generate the haxe and hxml parsers
+java -jar grammar-kit.jar gen ./grammar/haxe.bnf
+java -jar grammar-kit.jar gen ./src/com/intellij/plugins/haxe/hxml/hxml.bnf
+


### PR DESCRIPTION
This scripts downloads Grammarkit and use it to build the haxe and hxml parsers from bnf. This worked on the Travis.ci on my fork.

I didn't test if the resulting parsers are correct yet, I'll start to integrate the scripts once I'm done with the last step (using Haxe to build JavaProtocol.hx).

I used an older version of GrammarKit. Like you mention last week, the latest version of GrammarKit fails to build the parsers.