### PR TITLE
Build haxe protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,14 @@ language: java
 jdk:
 - openjdk7
 - oraclejdk7
+before_script:
+  - sudo add-apt-repository ppa:eyecreate/haxe -y
+  - sudo apt-get update
+  - sudo apt-get install haxe -y
+  - mkdir ~/haxelib
+  - haxelib setup ~/haxelib
+  - haxelib install hxjava
+  - haxelib git debugger https://github.com/TiVo/debugger.git
+  - mkdir build
+  - mkdir report
 script: ./travis.sh

--- a/build-haxe-protocol.sh
+++ b/build-haxe-protocol.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pushd hxcpp-debugger-protocol/src
+haxe -lib debugger -java JavaProtocol -main JavaProtocol
+popd


### PR DESCRIPTION
Build the JavaProtocol.hx file into java classes. Thoses classes are used to communicate to the hxcpp debugger using sockets.