### PR TITLE
added make targets for test and build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+
+#build the intellij-haxe.jar file which can be
+#installed in Intellij
+default: parsers protocol
+	./build.sh
+
+#Build the Haxe and HXML parsers with GrammarKit,
+#using their BNF
+parsers:
+	./build-parsers.sh
+
+#Build the JavaProtocol.hx class into a Java class.
+#This class is used to communicate with the CPP debbugger
+#through socket
+protocol:
+	./build-haxe-protocol.sh
+
+#Build and run the unit tests
+test: parsers protocol
+	./travis.sh


### PR DESCRIPTION
This is just a basic Makefile. The idea is to document explicitely the different build targets.
This will also look better in the readme, just need to do:
```
make
```
to build and
```
make test
```
to run the tests instead of executing the shell scripts.

Another reason is that I might get rid of the shell scripts this week since Ant has tasks to call "wget". This will simplify the build and make it also work on Windows.