### PR TITLE
(Re)Allow "new" for extern and prototype function declarations.

### DIFF
--- a/gen/com/intellij/plugins/haxe/lang/parser/HaxeParser.java
+++ b/gen/com/intellij/plugins/haxe/lang/parser/HaxeParser.java
@@ -2032,7 +2032,7 @@ public class HaxeParser implements PsiParser {
   }
 
   /* ********************************************************** */
-  // (functionMacroMember| declarationAttribute)* 'function' componentName genericParam? '(' parameterList ')' typeTag? 'untyped'? (functionCommonBody | ';')
+  // (functionMacroMember| declarationAttribute)* 'function' (constructorName | componentName) genericParam? '(' parameterList ')' typeTag? 'untyped'? (functionCommonBody | ';')
   public static boolean externFunctionDeclaration(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "externFunctionDeclaration")) return false;
     if (!nextTokenIs(b, "<extern function declaration>", KAUTOBUILD, KBUILD,
@@ -2044,7 +2044,7 @@ public class HaxeParser implements PsiParser {
     Marker m = enter_section_(b, l, _NONE_, "<extern function declaration>");
     r = externFunctionDeclaration_0(b, l + 1);
     r = r && consumeToken(b, KFUNCTION);
-    r = r && componentName(b, l + 1);
+    r = r && externFunctionDeclaration_2(b, l + 1);
     p = r; // pin = 3
     r = r && report_error_(b, externFunctionDeclaration_3(b, l + 1));
     r = p && report_error_(b, consumeToken(b, PLPAREN)) && r;
@@ -2076,6 +2076,17 @@ public class HaxeParser implements PsiParser {
     Marker m = enter_section_(b);
     r = functionMacroMember(b, l + 1);
     if (!r) r = declarationAttribute(b, l + 1);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  // constructorName | componentName
+  private static boolean externFunctionDeclaration_2(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "externFunctionDeclaration_2")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = constructorName(b, l + 1);
+    if (!r) r = componentName(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
   }
@@ -2427,7 +2438,7 @@ public class HaxeParser implements PsiParser {
   }
 
   /* ********************************************************** */
-  // (functionMacroMember| declarationAttribute)* 'function' componentName genericParam? '(' parameterList ')' typeTag? 'untyped'? ';'
+  // (functionMacroMember| declarationAttribute)* 'function' (constructorName | componentName) genericParam? '(' parameterList ')' typeTag? 'untyped'? ';'
   public static boolean functionPrototypeDeclarationWithAttributes(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "functionPrototypeDeclarationWithAttributes")) return false;
     if (!nextTokenIs(b, "<function prototype declaration with attributes>", KAUTOBUILD, KBUILD,
@@ -2439,7 +2450,7 @@ public class HaxeParser implements PsiParser {
     Marker m = enter_section_(b, l, _NONE_, "<function prototype declaration with attributes>");
     r = functionPrototypeDeclarationWithAttributes_0(b, l + 1);
     r = r && consumeToken(b, KFUNCTION);
-    r = r && componentName(b, l + 1);
+    r = r && functionPrototypeDeclarationWithAttributes_2(b, l + 1);
     p = r; // pin = 3
     r = r && report_error_(b, functionPrototypeDeclarationWithAttributes_3(b, l + 1));
     r = p && report_error_(b, consumeToken(b, PLPAREN)) && r;
@@ -2471,6 +2482,17 @@ public class HaxeParser implements PsiParser {
     Marker m = enter_section_(b);
     r = functionMacroMember(b, l + 1);
     if (!r) r = declarationAttribute(b, l + 1);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  // constructorName | componentName
+  private static boolean functionPrototypeDeclarationWithAttributes_2(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "functionPrototypeDeclarationWithAttributes_2")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = constructorName(b, l + 1);
+    if (!r) r = componentName(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
   }

--- a/gen/com/intellij/plugins/haxe/lang/psi/HaxeExternFunctionDeclaration.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/HaxeExternFunctionDeclaration.java
@@ -34,7 +34,7 @@ public interface HaxeExternFunctionDeclaration extends HaxeMethod {
   @NotNull
   List<HaxeBuildMacro> getBuildMacroList();
 
-  @NotNull
+  @Nullable
   HaxeComponentName getComponentName();
 
   @NotNull

--- a/gen/com/intellij/plugins/haxe/lang/psi/HaxeFunctionPrototypeDeclarationWithAttributes.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/HaxeFunctionPrototypeDeclarationWithAttributes.java
@@ -31,7 +31,7 @@ public interface HaxeFunctionPrototypeDeclarationWithAttributes extends HaxeMeth
   @NotNull
   List<HaxeBuildMacro> getBuildMacroList();
 
-  @NotNull
+  @Nullable
   HaxeComponentName getComponentName();
 
   @NotNull

--- a/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeExternFunctionDeclarationImpl.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeExternFunctionDeclarationImpl.java
@@ -58,9 +58,9 @@ public class HaxeExternFunctionDeclarationImpl extends HaxeMethodImpl implements
   }
 
   @Override
-  @NotNull
+  @Nullable
   public HaxeComponentName getComponentName() {
-    return findNotNullChildByClass(HaxeComponentName.class);
+    return findChildByClass(HaxeComponentName.class);
   }
 
   @Override

--- a/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeFunctionPrototypeDeclarationWithAttributesImpl.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeFunctionPrototypeDeclarationWithAttributesImpl.java
@@ -52,9 +52,9 @@ public class HaxeFunctionPrototypeDeclarationWithAttributesImpl extends HaxeMeth
   }
 
   @Override
-  @NotNull
+  @Nullable
   public HaxeComponentName getComponentName() {
-    return findNotNullChildByClass(HaxeComponentName.class);
+    return findChildByClass(HaxeComponentName.class);
   }
 
   @Override

--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -323,11 +323,11 @@ private constructorName ::= 'new'
 
 private localFunctionDeclarationAttribute ::= 'inline';
 
-externFunctionDeclaration ::= (functionMacroMember| declarationAttribute)* 'function' componentName genericParam? '(' parameterList ')' typeTag? 'untyped'? (functionCommonBody | ';')
+externFunctionDeclaration ::= (functionMacroMember| declarationAttribute)* 'function' (constructorName | componentName) genericParam? '(' parameterList ')' typeTag? 'untyped'? (functionCommonBody | ';')
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeMethod"}
 functionDeclarationWithAttributes ::= (functionMacroMember | declarationAttribute)* 'function' (constructorName | componentName) genericParam? '(' parameterList ')' typeTag? 'untyped'? functionCommonBody
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeMethod"}
-functionPrototypeDeclarationWithAttributes ::= (functionMacroMember| declarationAttribute)* 'function' componentName genericParam? '(' parameterList ')' typeTag? 'untyped'? ';'
+functionPrototypeDeclarationWithAttributes ::= (functionMacroMember| declarationAttribute)* 'function' (constructorName | componentName) genericParam? '(' parameterList ')' typeTag? 'untyped'? ';'
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeMethod"}
 localFunctionDeclaration ::= localFunctionDeclarationAttribute? 'function' componentName genericParam? '(' parameterList? ')' typeTag? 'untyped'? functionCommonBody
 {pin=2 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeMethod"}


### PR DESCRIPTION
Most of the unit tests that were broken in the GotoDeclaration section were because the 'new' keyword was removed from the xxxFunctionxxx declarations in haxe.bnf.  This adds them back in.

(Since Yannick thinks we should use temporary branches for code reviews, I decided to give it a whirl.)
