### PR TITLE
version of IDEA to use is now a parameter of build scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
+#Default IDEA version to build against, can be overriden
+#by env variable
+IDEA_VERSION?=13.1.6
 
 #build the intellij-haxe.jar file which can be
 #installed in Intellij
 default: parsers protocol
-	./build.sh
+	./build.sh $(IDEA_VERSION)
 
 #Build the Haxe and HXML parsers with GrammarKit,
 #using their BNF
@@ -17,4 +20,4 @@ protocol:
 
 #Build and run the unit tests
 test: parsers protocol
-	./travis.sh
+	./travis.sh $(IDEA_VERSION)

--- a/fetchIdea.sh
+++ b/fetchIdea.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-ideaVersion="13.1.6"
+if [[ $# -eq 0 ]] ; then
+    echo 'This script must be called with the version of IDEA to fetch'
+    echo 'example: ./fetchIdea.sh 13.1.6'
+    exit 1
+fi
+
+ideaVersion=$1
 
 if [ ! -d ./idea-IU ]; then
     # Get our IDEA dependency

--- a/travis.sh
+++ b/travis.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-./fetchIdea.sh
+if [[ $# -eq 0 ]] ; then
+    echo 'This script must be called with the version of IDEA to test'
+    echo 'example: ./travis.sh 13.1.6'
+    exit 1
+fi
+
+./fetchIdea.sh "$1"
 
 # Run the tests
 if [ "$1" = "-d" ]; then


### PR DESCRIPTION
This is a first step to be able to build any version of IDEA from command line.

Next, I'll implement the mechanism needed to include only some Java files based on the IDEA version.