### PR TITLE
build jar script takes IDEA version as input

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
-./fetchIdea.sh
+if [[ $# -eq 0 ]] ; then
+    echo 'This script must be called with the version of IDEA to build'
+    echo 'example: ./build.sh 13.1.6'
+    exit 1
+fi
+
+./fetchIdea.sh "$1"
 
 ant -f build.xml -DIDEA_HOME=./idea-IU


### PR DESCRIPTION
Same as previous PR, I forgot to also parametrize the "build jar" script.