### PR TITLE
Include based on version

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -4,6 +4,14 @@
     <property name="build.compiler" value="modern"/>
     <property name="idea.ultimate.build" location="${basedir}/idea-IU/" />
 
+    <!-- defines a path for code specific to an intellij version.
+         intellij SDK has non-backward compatible changes which requires
+         some duplicated Java files.
+
+         This property defaults to "src" if missing, this way you can
+         choose not to include any version specific code -->
+    <property name="version.specific.code.location" location="src" />
+
     <path id="idea.classpath">
         <fileset dir="${idea.ultimate.build}/lib">
             <include name="*.jar"/>
@@ -65,6 +73,7 @@
             target="1.6"
             includeantruntime="false" >
 
+            <src path="${version.specific.code.location}" />
             <src path="src" />
             <src path="gen" />
             <src path="testSrc" />

--- a/build.sh
+++ b/build.sh
@@ -8,4 +8,6 @@ fi
 
 ./fetchIdea.sh "$1"
 
-ant -f build.xml -DIDEA_HOME=./idea-IU
+#call the build script along with the path to a code package
+#specific to the intellij version which we build against
+ant -f build.xml -Dversion.specific.code.location=src/"$1"

--- a/build.xml
+++ b/build.xml
@@ -4,6 +4,14 @@
     <property name="build.compiler" value="modern"/>
     <property name="idea.ultimate.build" location="${basedir}/idea-IU/" />
 
+    <!-- defines a path for code specific to an intellij version.
+         intellij SDK has non-backward compatible changes which requires
+         some duplicated Java files.
+
+         This property defaults to "src" if missing, this way you can 
+         choose not to include any version specific code -->
+    <property name="version.specific.code.location" location="src" />
+
     <!-- javac2 is an intellij ant task to wrap the java compiler and add
          support to .form files and @NotNull annotations, among others -->
     <taskdef name="javac2" classname="com.intellij.ant.Javac2">
@@ -37,6 +45,7 @@
             target="1.6"
             includeantruntime="false" >
 
+            <src path="${version.specific.code.location}" />
             <src path="src" />
             <src path="gen" />
             <src path="common/src" />

--- a/build.xml
+++ b/build.xml
@@ -27,7 +27,7 @@
         <echo message="Using JAVA_HOME: ${java.home}" />
     </target>
 
-    <target name="compile_test" depends="clean,init" description="Compile tests">
+    <target name="compile" depends="clean,init" description="Compile tests">
 
         <javac2
             destdir="build"
@@ -49,7 +49,7 @@
 
     </target>
 
-    <target name="package" depends="compile_test" description="generate jar file">
+    <target name="package" depends="compile" description="generate jar file">
         <jar jarfile="intellij-haxe.jar" update="true">
             <fileset dir="build" includes="**/*.*" />
             <fileset dir="src" excludes="**/*.java" />

--- a/travis.sh
+++ b/travis.sh
@@ -9,11 +9,7 @@ fi
 ./fetchIdea.sh "$1"
 
 # Run the tests
-if [ "$1" = "-d" ]; then
-    ant -d -f build-test.xml -DIDEA_HOME=./idea-IU
-else
-    ant -f build-test.xml -DIDEA_HOME=./idea-IU
-fi
+ant -f build-test.xml -Dversion.specific.code.location=src/"$1"
 
 # Was our build successful?
 stat=$?


### PR DESCRIPTION
When building the jar, this allows for adding an extra source folder which is specific to IDEA version.

For example, if building for 13.1.6, then the folder "src/13.1.6" will be included in the build.