### PR TITLE
Fixes the last broken test in the FixGoToDeclarationActionTest.

### DIFF
--- a/src/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxePsiClass.java
+++ b/src/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxePsiClass.java
@@ -74,8 +74,20 @@ public abstract class AbstractHaxePsiClass extends AbstractHaxeNamedComponent im
     if (getParent() == null) {
       return name == null ? "" : name;
     }
-    return HaxeResolveUtil.joinQName(HaxeResolveUtil.getPackageName(getContainingFile()), name);
+    final String fileName = FileUtil.getNameWithoutExtension(getContainingFile().getName());
+    String packageName = HaxeResolveUtil.getPackageName(getContainingFile());
+    if (isAncillaryClass(name, fileName)) {
+      packageName = HaxeResolveUtil.joinQName(packageName, fileName);
+    }
+    return HaxeResolveUtil.joinQName(packageName, name);
   }
+
+  private boolean isAncillaryClass(String name, String fileName) {
+    return (!(this instanceof  HaxeExternClassDeclaration)) &&
+           (!fileName.equals(name)) &&
+           (HaxeResolveUtil.findComponentDeclaration(getContainingFile(), fileName) != null);
+  }
+
 
   @Override
   public boolean isInterface() {


### PR DESCRIPTION
@sganapavarapu1 - Srikanth, can you please review this?  It reverts part of a change made back when you were trying to get the package and file names to display inside the parenthesis in the hierarchy panels.  I had to revert it because the original change broke the file/class indexing mechanism.  I didn't see any negative effect on the panels after reverting this, so it's not readily apparent what you were fixing at the time.
