### PR TITLE
Fix HaxeAnnotationTest.

### DIFF
--- a/src/com/intellij/plugins/haxe/ide/annotator/HaxeColorAnnotator.java
+++ b/src/com/intellij/plugins/haxe/ide/annotator/HaxeColorAnnotator.java
@@ -37,6 +37,7 @@ import com.intellij.plugins.haxe.ide.module.HaxeModuleType;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypeSets;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.lang.psi.impl.HaxeReferenceImpl;
 import com.intellij.plugins.haxe.util.HaxeResolveUtil;
 import com.intellij.plugins.haxe.util.HaxeStringUtil;
 import com.intellij.psi.PsiElement;
@@ -68,7 +69,7 @@ public class HaxeColorAnnotator implements Annotator {
         tryAnnotateQName(node, holder);
         return;
       }
-      element = ((HaxeReference)element).resolve();
+      element = ((HaxeReference)element).resolveToComponentName();
     }
     if (element instanceof HaxeComponentName) {
       final boolean isStatic = checkStatic(element.getParent());

--- a/src/com/intellij/plugins/haxe/lang/psi/HaxeReference.java
+++ b/src/com/intellij/plugins/haxe/lang/psi/HaxeReference.java
@@ -17,10 +17,7 @@
  */
 package com.intellij.plugins.haxe.lang.psi;
 
-import com.intellij.psi.PsiJavaCodeReferenceElement;
-import com.intellij.psi.PsiReference;
-import com.intellij.psi.PsiReferenceExpression;
-import com.intellij.psi.PsiType;
+import com.intellij.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -33,4 +30,7 @@ public interface HaxeReference extends HaxeExpression, PsiJavaCodeReferenceEleme
 
   @Nullable
   PsiType getPsiType();
+
+  @Nullable
+  PsiElement resolveToComponentName();
 }


### PR DESCRIPTION
Fix coloring identifiers in code by resolving identifier references
to their component names in the color annotator.
Fixes HaxeAnnotationTest.testIDEA_100331.