### PR TITLE
fix, additional folder for a version is no longer required

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,4 +10,8 @@ fi
 
 #call the build script along with the path to a code package
 #specific to the intellij version which we build against
-ant -f build.xml -Dversion.specific.code.location=src/"$1"
+if [ -d src/"$1" ]; then
+    ant -f build.xml -Dversion.specific.code.location=src/"$1"
+else
+    ant -f build.xml
+fi

--- a/travis.sh
+++ b/travis.sh
@@ -9,7 +9,11 @@ fi
 ./fetchIdea.sh "$1"
 
 # Run the tests
-ant -f build-test.xml -Dversion.specific.code.location=src/"$1"
+if [ -d src/"$1" ]; then
+    ant -f build.xml -Dversion.specific.code.location=src/"$1"
+else
+    ant -f build.xml
+fi
 
 # Was our build successful?
 stat=$?


### PR DESCRIPTION
Without that, running `make` would fail because folder `src/13.1.6` does not exists. The code folders for specific versions should be optional