### PR TITLE
only build oraclejdk on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-- openjdk7
 - oraclejdk7
 before_script:
 - sudo add-apt-repository ppa:eyecreate/haxe -y


### PR DESCRIPTION
Just discussed this with @sganapavarapu1.
There is no need to build openjdk, it makes the build twice as slow and when travis deploys the .jar on the nightly build, it's not obvious to me which one has been deployed.