### PR TITLE
Revert visibility determination for methods.

### DIFF
--- a/src/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxeNamedComponent.java
+++ b/src/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxeNamedComponent.java
@@ -190,7 +190,7 @@ abstract public class AbstractHaxeNamedComponent extends HaxePsiCompositeElement
       }
     }
 
-    return true; // <default>: public
+    return false; // <default>: private
   }
 
   @Override

--- a/src/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
+++ b/src/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
@@ -287,23 +287,6 @@ public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent 
     return param;
   }
 
-  private boolean isPrivate() {
-    final List<HaxeDeclarationAttribute> declarationAttributeList = getDeclarationAttributeList();
-    if (declarationAttributeList != null) {
-      for (HaxeDeclarationAttribute declarationAttribute : declarationAttributeList) {
-        HaxeAccess access = declarationAttribute.getAccess();
-        if (access!=null && "private".equals(access.getText())) {
-            return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  @Override
-  public boolean isPublic() {
-    return (!isPrivate() && super.isPublic()); // do not change the order of- and the- expressions
-  }
 
   @NotNull
   @Override
@@ -337,11 +320,11 @@ public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent 
     // -- below modifiers need to be set individually
     //    because, they cannot be enforced through macro-list
 
-    if (isStatic()) {
+    if (super.isStatic()) {
       list.setModifierProperty(HaxePsiModifier.STATIC, true);
     }
 
-    if (isPublic()) {
+    if (super.isPublic()) {
       list.setModifierProperty(HaxePsiModifier.PUBLIC, true);
     }
     else {


### PR DESCRIPTION
Fixes unit test ReferenceCompletionTest.testPrivateMethod().

@sganapavarapu1 - Srikanth, can you please review this.  I removed some code and a strong warning you had written.  I suspect you had written the code because the superclass implementation of isPublic() was returning the wrong default, but I don't know that for sure.  Let me know if I'm missing something.