### PR TITLE
add intellij version to the name of the built plugin jar

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ fi
 #call the build script along with the path to a code package
 #specific to the intellij version which we build against
 if [ -d src/"$1" ]; then
-    ant -f build.xml -Dversion.specific.code.location=src/"$1"
+    ant -f build.xml -Dversion.specific.code.location=src/"$1" -Dversion="$1"
 else
-    ant -f build.xml
+    ant -f build.xml -Dversion="$1"
 fi

--- a/build.xml
+++ b/build.xml
@@ -12,6 +12,9 @@
          choose not to include any version specific code -->
     <property name="version.specific.code.location" location="src" />
 
+    <!-- the version of intellij we are building against -->
+    <property name="version" value="13.1.6" />
+
     <!-- javac2 is an intellij ant task to wrap the java compiler and add
          support to .form files and @NotNull annotations, among others -->
     <taskdef name="javac2" classname="com.intellij.ant.Javac2">
@@ -59,7 +62,7 @@
     </target>
 
     <target name="package" depends="compile" description="generate jar file">
-        <jar jarfile="intellij-haxe.jar" update="true">
+        <jar jarfile="intellij-haxe-${version}.jar" update="true">
             <fileset dir="build" includes="**/*.*" />
             <fileset dir="src" excludes="**/*.java" />
             <fileset dir="resources" />


### PR DESCRIPTION
For example, when building 13.1.6, it will generate:
```
intellij-haxe-13.1.6.jar
```