### PR TITLE
The idea SDK folder is cleaned after a build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,3 +15,5 @@ if [ -d src/"$1" ]; then
 else
     ant -f build.xml -Dversion="$1"
 fi
+
+rm -rf idea-IU

--- a/fetchIdea.sh
+++ b/fetchIdea.sh
@@ -8,20 +8,18 @@ fi
 
 ideaVersion=$1
 
-if [ ! -d ./idea-IU ]; then
-    # Get our IDEA dependency
-    if [ -f ~/Tools/ideaIU-${ideaVersion}.tar.gz ];
-    then
-        cp ~/Tools/ideaIU-${ideaVersion}.tar.gz .
-    else
-        wget http://download.jetbrains.com/idea/ideaIU-${ideaVersion}.tar.gz && mkdir -p ~/Tools && cp ideaIU-${ideaVersion}.tar.gz ~/Tools/ideaIU-${ideaVersion}.tar.gz
-    fi
-
-    # Unzip IDEA
-    tar zxf ideaIU-${ideaVersion}.tar.gz
-    rm -rf ideaIU-${ideaVersion}.tar.gz
-
-    # Move the versioned IDEA folder to a known location
-    ideaPath=$(find . -name 'idea-IU*' | head -n 1)
-    mv ${ideaPath} ./idea-IU
+# Get our IDEA dependency
+if [ -f ~/Tools/ideaIU-${ideaVersion}.tar.gz ];
+then
+    cp ~/Tools/ideaIU-${ideaVersion}.tar.gz .
+else
+    wget http://download.jetbrains.com/idea/ideaIU-${ideaVersion}.tar.gz && mkdir -p ~/Tools && cp ideaIU-${ideaVersion}.tar.gz ~/Tools/ideaIU-${ideaVersion}.tar.gz
 fi
+
+# Unzip IDEA
+tar zxf ideaIU-${ideaVersion}.tar.gz
+rm -rf ideaIU-${ideaVersion}.tar.gz
+
+# Move the versioned IDEA folder to a known location
+ideaPath=$(find . -name 'idea-IU*' | head -n 1)
+mv ${ideaPath} ./idea-IU

--- a/travis.sh
+++ b/travis.sh
@@ -18,10 +18,8 @@ fi
 # Was our build successful?
 stat=$?
 
-if [ "${TRAVIS}" != true ]; then
-    ant -f build-test.xml -q clean
-    rm -rf idea-IU
-fi
+ant -f build-test.xml -q clean
+rm -rf idea-IU
 
 # Return the build status
 exit ${stat}


### PR DESCRIPTION
This allows building multiple versions of idea in a row. Without this fix, they'll reuse the ```idea-UI``` folder which will cause the build to fail, as it won't be the right sdk version.

With this, you can run this command to build multiple versions:
```IDEA_VERSION=13.1.6 make && IDEA_VERSION=14.0.1 make```