### PR TITLE
Fix HaxeIntroduceVariable unit tests.

### DIFF
--- a/src/com/intellij/plugins/haxe/HaxeComponentType.java
+++ b/src/com/intellij/plugins/haxe/HaxeComponentType.java
@@ -150,12 +150,14 @@ public enum HaxeComponentType {
         element instanceof HaxeFunctionLiteral) {
       return FUNCTION;
     }
-    if (element instanceof HaxeVarDeclarationPart ||
+    if (element instanceof HaxeVarDeclaration ||
+        element instanceof HaxeVarDeclarationPart ||
         element instanceof HaxeEnumValueDeclaration ||
         element instanceof HaxeAnonymousTypeField) {
       return FIELD;
     }
-    if (element instanceof HaxeLocalVarDeclarationPart ||
+    if (element instanceof HaxeLocalVarDeclaration ||
+        element instanceof HaxeLocalVarDeclarationPart ||
         element instanceof HaxeForStatement) {
       return VARIABLE;
     }

--- a/src/com/intellij/plugins/haxe/ide/refactoring/introduce/HaxeIntroduceHandler.java
+++ b/src/com/intellij/plugins/haxe/ide/refactoring/introduce/HaxeIntroduceHandler.java
@@ -298,7 +298,7 @@ public abstract class HaxeIntroduceHandler implements RefactoringActionHandler {
       context = PsiTreeUtil.getParentOfType(context, HaxeComponent.class, true);
       type = HaxeComponentType.typeOf(context);
     }
-    while (type != null && notFunctionMethodClass(type));
+    while (type != null && notFunctionMethodClass(type));  // XXX-EBatTiVo: Probably should not stop if type == null.
     if (context == null) {
       context = expression.getContainingFile();
     }

--- a/src/com/intellij/plugins/haxe/lang/psi/HaxeComponent.java
+++ b/src/com/intellij/plugins/haxe/lang/psi/HaxeComponent.java
@@ -22,5 +22,5 @@ import com.intellij.psi.PsiNamedElement;
 /**
  * @author: Fedor.Korotkov
  */
-public interface HaxeComponent extends HaxePsiCompositeElement, PsiNamedElement, HaxeNamedComponent {
+public interface HaxeComponent extends  HaxeNamedComponent, PsiNamedElement {
 }

--- a/src/com/intellij/plugins/haxe/lang/psi/HaxePsiField.java
+++ b/src/com/intellij/plugins/haxe/lang/psi/HaxePsiField.java
@@ -22,5 +22,15 @@ import com.intellij.psi.PsiField;
 /**
  * Created by srikanthg on 10/9/14.
  */
-public interface HaxePsiField extends HaxeNamedComponent, PsiField {
+//
+// NOTE: This class MUST derive from HaxeComponent -- not HaxeNamedComponent for
+// certain refactorings (that use HaxeQualifiedNameProvider) to work correctly.
+// If the derivation changes, an exception is thrown out of than class, and
+// refactorings requiring names silently fail (becase of a cast exception).
+// See testSrc/com/intellij/plugins/haxe/ide/refactoring/introduce/HaxeIntroduceVariableTest#ReplaceAll3()
+//
+//                                    |||||||||||||
+//                                    vvvvvvvvvvvvv
+public interface HaxePsiField extends HaxeComponent, PsiField {
+
 }

--- a/src/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
+++ b/src/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
@@ -209,12 +209,6 @@ public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent 
     return PsiTreeUtil.getParentOfType(this, HaxeClass.class, true);
   }
 
-  @Override
-  public PsiElement getContext() {
-    final PsiClass cc = getContainingClass();
-    return cc != null ? cc : super.getContext();
-  }
-
   @NotNull
   @Override
   public MethodSignature getSignature(@NotNull PsiSubstitutor substitutor) {


### PR DESCRIPTION
Unit test fixes: HaxeIntroduceVariableTest.testReplaceAll3
    Two primary issues:  The first was a change in the BNF that changed the
    underlying type of HaxeLocalVarDeclaration to a HaxePsiField.  The second
    was changing the type of HaxePsiField from a HaxeComponent to a
    HaxeNamedComponent.
    
In the first case, the change itself wasn't really a problem; it was that
    HaxeComponentType.typeOf() hadn't been changed to reflect the new reality
    that it was going to be asked about HAXE_LOCAL_VAR_DECLARATION types.  It
    simply returned null for types it didn't know about, thus
    HaxeIntroduceHandler.getOccurrences() stopped its loop looking for the
    enclosing method element.  The fix was simply to add that type to the list
    of classifications.  HAXE_VAR_DECLARATION was also added as future-proofing.
    
In the second case, HaxePsiField must be a HaxeComponent for
    HaxeQualifiedNameProvider to work correctly.  If it is not a HaxeComponent,
    a ClassCastException is thrown and refactorings requiring names silently fail.


Fix unit test HaxeMethodPsiMixinImpl.testSuggestName2()
    Reverts part of change 15b15746de19cd7a5132666fa361b8ef88a47058
    which added an override for HaxeMethodPsiMixinImpl.getContext().  The
    override called getContainingClass() instead of getParent().  That
    caused a tree_walk_up to skip several nodes, notably the CLASS_BODY
    element, and HaxeIntroduceHandler could no longer walk all of its
    children to find all of the fields in a class.  Thus, for the test case
    names were suggested that clashed with a function name.