### PR TITLE
Make runs of a single unit test use the HaxeAstFactory.

### DIFF
--- a/testSrc/com/intellij/plugins/haxe/lang/parser/HaxeParsingTestBase.java
+++ b/testSrc/com/intellij/plugins/haxe/lang/parser/HaxeParsingTestBase.java
@@ -17,15 +17,10 @@
  */
 package com.intellij.plugins.haxe.lang.parser;
 
-import com.intellij.lang.ASTFactory;
-import com.intellij.lang.DefaultASTFactory;
-import com.intellij.lang.DefaultASTFactoryImpl;
 import com.intellij.lang.LanguageASTFactory;
-import com.intellij.lang.java.JavaLanguage;
 import com.intellij.plugins.haxe.HaxeFileType;
 import com.intellij.plugins.haxe.HaxeLanguage;
 import com.intellij.plugins.haxe.util.HaxeTestUtils;
-import com.intellij.psi.impl.source.tree.JavaASTFactory;
 import com.intellij.testFramework.ParsingTestCase;
 
 abstract public class HaxeParsingTestBase extends ParsingTestCase {

--- a/testSrc/com/intellij/plugins/haxe/lang/parser/HaxeParsingTestBase.java
+++ b/testSrc/com/intellij/plugins/haxe/lang/parser/HaxeParsingTestBase.java
@@ -17,13 +17,26 @@
  */
 package com.intellij.plugins.haxe.lang.parser;
 
+import com.intellij.lang.ASTFactory;
+import com.intellij.lang.DefaultASTFactory;
+import com.intellij.lang.DefaultASTFactoryImpl;
+import com.intellij.lang.LanguageASTFactory;
+import com.intellij.lang.java.JavaLanguage;
 import com.intellij.plugins.haxe.HaxeFileType;
+import com.intellij.plugins.haxe.HaxeLanguage;
 import com.intellij.plugins.haxe.util.HaxeTestUtils;
+import com.intellij.psi.impl.source.tree.JavaASTFactory;
 import com.intellij.testFramework.ParsingTestCase;
 
 abstract public class HaxeParsingTestBase extends ParsingTestCase {
   public HaxeParsingTestBase(String... path) {
     super(getPath(path), HaxeFileType.DEFAULT_EXTENSION, new HaxeParserDefinition());
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    addExplicitExtension(LanguageASTFactory.INSTANCE, HaxeLanguage.INSTANCE, new HaxeAstFactory());
   }
 
   private static String getPath(String... args) {


### PR DESCRIPTION
Fixes issue #125.

Some of the unit tests use HeavyUnitTestFixture, which sets up the HaxeAstFactory
correctly via having Idea use plugin.xml for setup.  Once any unit test uses it,
all following tests get the benefit because Idea doesn't shut down between tests.
However, when tests are run singly (for quicker turnaround, generally),
particularly parsing unit tests which use a very light-weight test base class,
the full app setup is skipped.  This fix sets up the factory for Haxe when
parsing tests are created.