### PR TITLE
Show compiler command line in the output window.

### DIFF
--- a/common/src/com/intellij/plugins/haxe/compilation/HaxeCompilerError.java
+++ b/common/src/com/intellij/plugins/haxe/compilation/HaxeCompilerError.java
@@ -102,10 +102,18 @@ public class HaxeCompilerError {
             rawColumn = "-1";
             text = m.group(3).trim();
         }
-        // Error:(.*)
+        // ([^:]*)Error:(.*)
         else if ((m = pBareError.matcher(message)).matches()) {
+          StringBuilder err = new StringBuilder();
+          String errType = m.group(1).trim();
+          if (!errType.isEmpty()) {
+            err.append(" (");
+            err.append(errType);
+            err.append(") ");
+          }
+          err.append(m.group(2).trim());
           return new HaxeCompilerError(CompilerMessageCategory.ERROR,
-                                       m.group(1).trim(), "", -1, -1);
+                                       err.toString(), "", -1, -1);
         }
         // Anything that doesn't match error patterns is purely informational
         else {
@@ -159,7 +167,7 @@ public class HaxeCompilerError {
 
     static Pattern pLibraryNotInstalled = Pattern.compile
         ("Error: Library ([\\S]+) is not installed(.*)");
-    static Pattern pBareError = Pattern.compile("Error:(.*)");
+    static Pattern pBareError = Pattern.compile("([^:]*)Error:(.*)", Pattern.CASE_INSENSITIVE);
     static Pattern pColumnError = 
         Pattern.compile("([^:]+):([\\d]+): characters ([\\d]+)-[\\d]+ :(.*)");
     static Pattern pLineError =

--- a/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
+++ b/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
@@ -59,6 +59,8 @@ public class HaxeCommonCompilerUtil {
     Boolean getIsTestBuild();
 
     void errorHandler(String message);
+    void warningHandler(String message);
+    void infoHandler(String message);
 
     void log(String message);
 
@@ -179,6 +181,17 @@ public class HaxeCommonCompilerUtil {
     }
     else {
       setupUserProperties(commandLine, context);
+    }
+
+    // Show the command line in the output window.
+    // TODO: Make a checkbox in the SDK configuration window.
+    if (!commandLine.isEmpty()) {
+      StringBuilder cl = new StringBuilder("Executing: ");
+      for (String commandPart : commandLine) {
+        cl.append(commandPart);
+        cl.append(" ");
+      }
+      context.infoHandler(cl.toString());
     }
 
     final BooleanValueHolder hasErrors = new BooleanValueHolder(false);

--- a/jps-plugin/src/org/jetbrains/jps/haxe/build/HaxeModuleLevelBuilder.java
+++ b/jps-plugin/src/org/jetbrains/jps/haxe/build/HaxeModuleLevelBuilder.java
@@ -154,6 +154,15 @@ public class HaxeModuleLevelBuilder extends ModuleLevelBuilder {
       public void errorHandler(String message) {
         context.processMessage(new CompilerMessage(BUILDER_NAME, BuildMessage.Kind.ERROR, message));
       }
+      @Override
+      public void warningHandler(String message) {
+        context.processMessage(new CompilerMessage(BUILDER_NAME, BuildMessage.Kind.WARNING, message));
+      }
+
+      @Override
+      public void infoHandler(String message) {
+        context.processMessage(new CompilerMessage(BUILDER_NAME, BuildMessage.Kind.INFO, message));
+      }
 
       @Override
       public void log(String message) {

--- a/src/common/com/intellij/plugins/haxe/compilation/HaxeCompiler.java
+++ b/src/common/com/intellij/plugins/haxe/compilation/HaxeCompiler.java
@@ -240,6 +240,20 @@ public class HaxeCompiler implements SourceProcessingCompiler {
       }
 
       @Override
+      public void warningHandler(String message) {
+        context.addMessage(CompilerMessageCategory.WARNING, message, null, -1, -1);
+      }
+
+      @Override
+      public void infoHandler(String message) {
+        context.addMessage(CompilerMessageCategory.INFORMATION, message, null, -1, -1);
+      }
+
+      public void statisticsHandler(String message) {
+        context.addMessage(CompilerMessageCategory.INFORMATION, message, null, -1, -1);
+      }
+
+      @Override
       public void log(String message) {
         LOG.debug(message);
       }


### PR DESCRIPTION
Also, make error detection in compiler output find more generic errors by
loosening the regular expression.