### PR TITLE
use separate privateKeyWord and externKeyWord instead of externOrPrivate

### DIFF
--- a/gen/com/intellij/plugins/haxe/lang/lexer/HaxeTokenTypes.java
+++ b/gen/com/intellij/plugins/haxe/lang/lexer/HaxeTokenTypes.java
@@ -72,7 +72,7 @@ public interface HaxeTokenTypes {
   IElementType EXTERN_CLASS_DECLARATION_BODY = new HaxeElementType("EXTERN_CLASS_DECLARATION_BODY");
   IElementType EXTERN_FUNCTION_DECLARATION = new HaxeElementType("EXTERN_FUNCTION_DECLARATION");
   IElementType EXTERN_INTERFACE_DECLARATION = new HaxeElementType("EXTERN_INTERFACE_DECLARATION");
-  IElementType EXTERN_OR_PRIVATE = new HaxeElementType("EXTERN_OR_PRIVATE");
+  IElementType EXTERN_KEY_WORD = new HaxeElementType("EXTERN_KEY_WORD");
   IElementType FAKE_ENUM_META = new HaxeElementType("FAKE_ENUM_META");
   IElementType FAT_ARROW_EXPRESSION = new HaxeElementType("FAT_ARROW_EXPRESSION");
   IElementType FINAL_META = new HaxeElementType("FINAL_META");
@@ -437,8 +437,8 @@ public interface HaxeTokenTypes {
       else if (type == EXTERN_INTERFACE_DECLARATION) {
         return new HaxeExternInterfaceDeclarationImpl(node);
       }
-      else if (type == EXTERN_OR_PRIVATE) {
-        return new HaxeExternOrPrivateImpl(node);
+      else if (type == EXTERN_KEY_WORD) {
+        return new HaxeExternKeyWordImpl(node);
       }
       else if (type == FAKE_ENUM_META) {
         return new HaxeFakeEnumMetaImpl(node);

--- a/gen/com/intellij/plugins/haxe/lang/parser/HaxeParser.java
+++ b/gen/com/intellij/plugins/haxe/lang/parser/HaxeParser.java
@@ -178,8 +178,8 @@ public class HaxeParser implements PsiParser {
     else if (t == EXTERN_INTERFACE_DECLARATION) {
       r = externInterfaceDeclaration(b, 0);
     }
-    else if (t == EXTERN_OR_PRIVATE) {
-      r = externOrPrivate(b, 0);
+    else if (t == EXTERN_KEY_WORD) {
+      r = externKeyWord(b, 0);
     }
     else if (t == FAKE_ENUM_META) {
       r = fakeEnumMeta(b, 0);
@@ -1935,29 +1935,54 @@ public class HaxeParser implements PsiParser {
   }
 
   /* ********************************************************** */
-  // privateKeyWord? 'extern' privateKeyWord?
+  // externAndMaybePrivate2 | externAndMaybePrivate1
   static boolean externAndMaybePrivate(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "externAndMaybePrivate")) return false;
     if (!nextTokenIs(b, "", KEXTERN, KPRIVATE)) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = externAndMaybePrivate_0(b, l + 1);
-    r = r && consumeToken(b, KEXTERN);
-    r = r && externAndMaybePrivate_2(b, l + 1);
+    r = externAndMaybePrivate2(b, l + 1);
+    if (!r) r = externAndMaybePrivate1(b, l + 1);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  /* ********************************************************** */
+  // privateKeyWord? externKeyWord
+  static boolean externAndMaybePrivate1(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "externAndMaybePrivate1")) return false;
+    if (!nextTokenIs(b, "", KEXTERN, KPRIVATE)) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = externAndMaybePrivate1_0(b, l + 1);
+    r = r && externKeyWord(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
   }
 
   // privateKeyWord?
-  private static boolean externAndMaybePrivate_0(PsiBuilder b, int l) {
-    if (!recursion_guard_(b, l, "externAndMaybePrivate_0")) return false;
+  private static boolean externAndMaybePrivate1_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "externAndMaybePrivate1_0")) return false;
     privateKeyWord(b, l + 1);
     return true;
   }
 
+  /* ********************************************************** */
+  // externKeyWord privateKeyWord?
+  static boolean externAndMaybePrivate2(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "externAndMaybePrivate2")) return false;
+    if (!nextTokenIs(b, KEXTERN)) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = externKeyWord(b, l + 1);
+    r = r && externAndMaybePrivate2_1(b, l + 1);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
   // privateKeyWord?
-  private static boolean externAndMaybePrivate_2(PsiBuilder b, int l) {
-    if (!recursion_guard_(b, l, "externAndMaybePrivate_2")) return false;
+  private static boolean externAndMaybePrivate2_1(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "externAndMaybePrivate2_1")) return false;
     privateKeyWord(b, l + 1);
     return true;
   }
@@ -2171,15 +2196,42 @@ public class HaxeParser implements PsiParser {
   }
 
   /* ********************************************************** */
-  // 'extern' | privateKeyWord
-  public static boolean externOrPrivate(PsiBuilder b, int l) {
-    if (!recursion_guard_(b, l, "externOrPrivate")) return false;
-    if (!nextTokenIs(b, "<extern or private>", KEXTERN, KPRIVATE)) return false;
+  // 'extern'
+  public static boolean externKeyWord(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "externKeyWord")) return false;
+    if (!nextTokenIs(b, KEXTERN)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<extern or private>");
+    Marker m = enter_section_(b);
     r = consumeToken(b, KEXTERN);
+    exit_section_(b, m, EXTERN_KEY_WORD, r);
+    return r;
+  }
+
+  /* ********************************************************** */
+  // externPrivate | privateExtern | privateKeyWord | externKeyWord
+  static boolean externOrPrivate(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "externOrPrivate")) return false;
+    if (!nextTokenIs(b, "", KEXTERN, KPRIVATE)) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = externPrivate(b, l + 1);
+    if (!r) r = privateExtern(b, l + 1);
     if (!r) r = privateKeyWord(b, l + 1);
-    exit_section_(b, l, m, EXTERN_OR_PRIVATE, r, false, null);
+    if (!r) r = externKeyWord(b, l + 1);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  /* ********************************************************** */
+  // externKeyWord privateKeyWord
+  static boolean externPrivate(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "externPrivate")) return false;
+    if (!nextTokenIs(b, KEXTERN)) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = externKeyWord(b, l + 1);
+    r = r && privateKeyWord(b, l + 1);
+    exit_section_(b, m, null, r);
     return r;
   }
 
@@ -4363,6 +4415,19 @@ public class HaxeParser implements PsiParser {
     if (!r) r = consumeToken(b, OPLUS_PLUS);
     if (!r) r = consumeToken(b, ONOT);
     if (!r) r = consumeToken(b, OCOMPLEMENT);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  /* ********************************************************** */
+  // privateKeyWord externKeyWord
+  static boolean privateExtern(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "privateExtern")) return false;
+    if (!nextTokenIs(b, KPRIVATE)) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = privateKeyWord(b, l + 1);
+    r = r && externKeyWord(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
   }

--- a/gen/com/intellij/plugins/haxe/lang/psi/HaxeEnumDeclaration.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/HaxeEnumDeclaration.java
@@ -32,12 +32,15 @@ public interface HaxeEnumDeclaration extends HaxeClass {
   HaxeEnumBody getEnumBody();
 
   @Nullable
-  HaxeExternOrPrivate getExternOrPrivate();
+  HaxeExternKeyWord getExternKeyWord();
 
   @Nullable
   HaxeGenericParam getGenericParam();
 
   @Nullable
   HaxeMacroClassList getMacroClassList();
+
+  @Nullable
+  HaxePrivateKeyWord getPrivateKeyWord();
 
 }

--- a/gen/com/intellij/plugins/haxe/lang/psi/HaxeExternClassDeclaration.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/HaxeExternClassDeclaration.java
@@ -31,6 +31,9 @@ public interface HaxeExternClassDeclaration extends HaxeClass {
   @Nullable
   HaxeExternClassDeclarationBody getExternClassDeclarationBody();
 
+  @NotNull
+  HaxeExternKeyWord getExternKeyWord();
+
   @Nullable
   HaxeGenericParam getGenericParam();
 
@@ -40,7 +43,7 @@ public interface HaxeExternClassDeclaration extends HaxeClass {
   @Nullable
   HaxeMacroClassList getMacroClassList();
 
-  @NotNull
-  List<HaxePrivateKeyWord> getPrivateKeyWordList();
+  @Nullable
+  HaxePrivateKeyWord getPrivateKeyWord();
 
 }

--- a/gen/com/intellij/plugins/haxe/lang/psi/HaxeExternKeyWord.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/HaxeExternKeyWord.java
@@ -23,27 +23,6 @@ import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 
-public interface HaxeExternInterfaceDeclaration extends HaxeClass {
-
-  @Nullable
-  HaxeComponentName getComponentName();
-
-  @Nullable
-  HaxeExternKeyWord getExternKeyWord();
-
-  @Nullable
-  HaxeGenericParam getGenericParam();
-
-  @Nullable
-  HaxeInheritList getInheritList();
-
-  @Nullable
-  HaxeInterfaceBody getInterfaceBody();
-
-  @Nullable
-  HaxeMacroClassList getMacroClassList();
-
-  @Nullable
-  HaxePrivateKeyWord getPrivateKeyWord();
+public interface HaxeExternKeyWord extends HaxePsiCompositeElement {
 
 }

--- a/gen/com/intellij/plugins/haxe/lang/psi/HaxeTypedefDeclaration.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/HaxeTypedefDeclaration.java
@@ -29,7 +29,7 @@ public interface HaxeTypedefDeclaration extends HaxeClass {
   HaxeComponentName getComponentName();
 
   @Nullable
-  HaxeExternOrPrivate getExternOrPrivate();
+  HaxeExternKeyWord getExternKeyWord();
 
   @Nullable
   HaxeFunctionType getFunctionType();
@@ -39,6 +39,9 @@ public interface HaxeTypedefDeclaration extends HaxeClass {
 
   @Nullable
   HaxeMacroClassList getMacroClassList();
+
+  @Nullable
+  HaxePrivateKeyWord getPrivateKeyWord();
 
   @Nullable
   HaxeTypeOrAnonymous getTypeOrAnonymous();

--- a/gen/com/intellij/plugins/haxe/lang/psi/HaxeVisitor.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/HaxeVisitor.java
@@ -212,7 +212,7 @@ public class HaxeVisitor extends PsiElementVisitor {
     visitClass(o);
   }
 
-  public void visitExternOrPrivate(@NotNull HaxeExternOrPrivate o) {
+  public void visitExternKeyWord(@NotNull HaxeExternKeyWord o) {
     visitPsiCompositeElement(o);
   }
 

--- a/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeEnumDeclarationImpl.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeEnumDeclarationImpl.java
@@ -53,8 +53,8 @@ public class HaxeEnumDeclarationImpl extends AbstractHaxePsiClass implements Hax
 
   @Override
   @Nullable
-  public HaxeExternOrPrivate getExternOrPrivate() {
-    return findChildByClass(HaxeExternOrPrivate.class);
+  public HaxeExternKeyWord getExternKeyWord() {
+    return findChildByClass(HaxeExternKeyWord.class);
   }
 
   @Override
@@ -67,6 +67,12 @@ public class HaxeEnumDeclarationImpl extends AbstractHaxePsiClass implements Hax
   @Nullable
   public HaxeMacroClassList getMacroClassList() {
     return findChildByClass(HaxeMacroClassList.class);
+  }
+
+  @Override
+  @Nullable
+  public HaxePrivateKeyWord getPrivateKeyWord() {
+    return findChildByClass(HaxePrivateKeyWord.class);
   }
 
 }

--- a/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeExternClassDeclarationImpl.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeExternClassDeclarationImpl.java
@@ -52,6 +52,12 @@ public class HaxeExternClassDeclarationImpl extends AbstractHaxePsiClass impleme
   }
 
   @Override
+  @NotNull
+  public HaxeExternKeyWord getExternKeyWord() {
+    return findNotNullChildByClass(HaxeExternKeyWord.class);
+  }
+
+  @Override
   @Nullable
   public HaxeGenericParam getGenericParam() {
     return findChildByClass(HaxeGenericParam.class);
@@ -70,9 +76,9 @@ public class HaxeExternClassDeclarationImpl extends AbstractHaxePsiClass impleme
   }
 
   @Override
-  @NotNull
-  public List<HaxePrivateKeyWord> getPrivateKeyWordList() {
-    return PsiTreeUtil.getChildrenOfTypeAsList(this, HaxePrivateKeyWord.class);
+  @Nullable
+  public HaxePrivateKeyWord getPrivateKeyWord() {
+    return findChildByClass(HaxePrivateKeyWord.class);
   }
 
 }

--- a/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeExternInterfaceDeclarationImpl.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeExternInterfaceDeclarationImpl.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2015 AS3Boyan
+ * Copyright 2014-2014 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // This is a generated file. Not intended for manual editing.
 package com.intellij.plugins.haxe.lang.psi.impl;
 
@@ -29,6 +47,12 @@ public class HaxeExternInterfaceDeclarationImpl extends AbstractHaxePsiClass imp
 
   @Override
   @Nullable
+  public HaxeExternKeyWord getExternKeyWord() {
+    return findChildByClass(HaxeExternKeyWord.class);
+  }
+
+  @Override
+  @Nullable
   public HaxeGenericParam getGenericParam() {
     return findChildByClass(HaxeGenericParam.class);
   }
@@ -52,9 +76,9 @@ public class HaxeExternInterfaceDeclarationImpl extends AbstractHaxePsiClass imp
   }
 
   @Override
-  @NotNull
-  public List<HaxePrivateKeyWord> getPrivateKeyWordList() {
-    return PsiTreeUtil.getChildrenOfTypeAsList(this, HaxePrivateKeyWord.class);
+  @Nullable
+  public HaxePrivateKeyWord getPrivateKeyWord() {
+    return findChildByClass(HaxePrivateKeyWord.class);
   }
 
 }

--- a/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeExternKeyWordImpl.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeExternKeyWordImpl.java
@@ -28,21 +28,15 @@ import com.intellij.psi.util.PsiTreeUtil;
 import static com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes.*;
 import com.intellij.plugins.haxe.lang.psi.*;
 
-public class HaxeExternOrPrivateImpl extends HaxePsiCompositeElementImpl implements HaxeExternOrPrivate {
+public class HaxeExternKeyWordImpl extends HaxePsiCompositeElementImpl implements HaxeExternKeyWord {
 
-  public HaxeExternOrPrivateImpl(ASTNode node) {
+  public HaxeExternKeyWordImpl(ASTNode node) {
     super(node);
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaxeVisitor) ((HaxeVisitor)visitor).visitExternOrPrivate(this);
+    if (visitor instanceof HaxeVisitor) ((HaxeVisitor)visitor).visitExternKeyWord(this);
     else super.accept(visitor);
-  }
-
-  @Override
-  @Nullable
-  public HaxePrivateKeyWord getPrivateKeyWord() {
-    return findChildByClass(HaxePrivateKeyWord.class);
   }
 
 }

--- a/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypedefDeclarationImpl.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypedefDeclarationImpl.java
@@ -47,8 +47,8 @@ public class HaxeTypedefDeclarationImpl extends AbstractHaxeTypeDefImpl implemen
 
   @Override
   @Nullable
-  public HaxeExternOrPrivate getExternOrPrivate() {
-    return findChildByClass(HaxeExternOrPrivate.class);
+  public HaxeExternKeyWord getExternKeyWord() {
+    return findChildByClass(HaxeExternKeyWord.class);
   }
 
   @Override
@@ -67,6 +67,12 @@ public class HaxeTypedefDeclarationImpl extends AbstractHaxeTypeDefImpl implemen
   @Nullable
   public HaxeMacroClassList getMacroClassList() {
     return findChildByClass(HaxeMacroClassList.class);
+  }
+
+  @Override
+  @Nullable
+  public HaxePrivateKeyWord getPrivateKeyWord() {
+    return findChildByClass(HaxePrivateKeyWord.class);
   }
 
   @Override

--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -254,8 +254,15 @@ private topLevelDeclaration ::= classDeclaration
                               | typedefDeclaration
 
 privateKeyWord ::= 'private'
-externOrPrivate ::= 'extern' | privateKeyWord
-private externAndMaybePrivate ::= privateKeyWord? 'extern' privateKeyWord?
+externKeyWord ::= 'extern'
+
+private externPrivate ::= externKeyWord privateKeyWord
+private privateExtern ::= privateKeyWord externKeyWord
+private externOrPrivate ::= externPrivate | privateExtern | privateKeyWord | externKeyWord
+
+private externAndMaybePrivate1 ::= privateKeyWord? externKeyWord
+private externAndMaybePrivate2 ::= externKeyWord privateKeyWord?
+private externAndMaybePrivate ::= externAndMaybePrivate2 | externAndMaybePrivate1
 
 typedefDeclaration ::= macroClassList? externOrPrivate? 'typedef' componentName genericParam? '=' functionTypeWrapper ';'?
 {pin=5 mixin="com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxeTypeDefImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeClass"}

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxePsiClass.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxePsiClass.java
@@ -385,30 +385,16 @@ public abstract class AbstractHaxePsiClass extends AbstractHaxeNamedComponent im
       privateKeyWord = ((HaxeAbstractClassDeclaration) this).getPrivateKeyWord();
     }
     else if (this instanceof HaxeExternClassDeclaration) { // extern class
-      List<HaxePrivateKeyWord> privateList = ((HaxeExternClassDeclaration) this).getPrivateKeyWordList();
-      for (HaxePrivateKeyWord privateModifier : privateList) {
-        if (privateModifier != null) {
-          privateKeyWord = privateModifier;
-          break; // XXX: does this need further searching / refining?
-        }
-      }
+      privateKeyWord = ((HaxeExternClassDeclaration)this).getPrivateKeyWord();
     }
-    else {
-      HaxeExternOrPrivate externOrPrivate = null;
-
-      if (this instanceof HaxeTypedefDeclaration) { // typedef
-        externOrPrivate = ((HaxeTypedefDeclaration) this).getExternOrPrivate();
-      }
-      else if (this instanceof HaxeInterfaceDeclaration) { // interface
-        privateKeyWord = ((HaxeInterfaceDeclaration) this).getPrivateKeyWord();
-      }
-      else if (this instanceof HaxeEnumDeclaration) { // enum
-        externOrPrivate = ((HaxeEnumDeclaration) this).getExternOrPrivate();
-      }
-
-      if (externOrPrivate != null) {
-        privateKeyWord = externOrPrivate.getPrivateKeyWord();
-      }
+    else if (this instanceof HaxeTypedefDeclaration) { // typedef
+      privateKeyWord = ((HaxeTypedefDeclaration) this).getPrivateKeyWord();
+    }
+    else if (this instanceof HaxeInterfaceDeclaration) { // interface
+      privateKeyWord = ((HaxeInterfaceDeclaration) this).getPrivateKeyWord();
+    }
+    else if (this instanceof HaxeEnumDeclaration) { // enum
+      privateKeyWord = ((HaxeEnumDeclaration) this).getPrivateKeyWord();
     }
     return (privateKeyWord != null);
   }

--- a/testData/parsing/haxe/declarations/class/FullOfMacro.txt
+++ b/testData/parsing/haxe/declarations/class/FullOfMacro.txt
@@ -281,7 +281,8 @@ Haxe File
                 PsiJavaToken:true('true')
             PsiJavaToken:)(')')
           PsiJavaToken:)(')')
-    PsiJavaToken:extern('extern ')
+    EXTERN_KEY_WORD
+      PsiJavaToken:extern('extern ')
     PRIVATE_KEY_WORD
       PsiJavaToken:private('private')
     PsiJavaToken:class('class')

--- a/testData/parsing/haxe/declarations/class/NativeRandom.txt
+++ b/testData/parsing/haxe/declarations/class/NativeRandom.txt
@@ -5,7 +5,8 @@ Haxe File
         SIMPLE_META
           FINAL_META
             PsiJavaToken:@:final('@:final')
-    PsiJavaToken:extern('extern ')
+    EXTERN_KEY_WORD
+      PsiJavaToken:extern('extern ')
     PsiJavaToken:class('class')
     COMPONENT_NAME
       IDENTIFIER
@@ -93,7 +94,8 @@ Haxe File
   EXTERN_CLASS_DECLARATION
     PRIVATE_KEY_WORD
       PsiJavaToken:private('private')
-    PsiJavaToken:extern('extern ')
+    EXTERN_KEY_WORD
+      PsiJavaToken:extern('extern ')
     PsiJavaToken:class('class')
     COMPONENT_NAME
       IDENTIFIER

--- a/testData/parsing/haxe/declarations/extern/Interface.txt
+++ b/testData/parsing/haxe/declarations/extern/Interface.txt
@@ -1,6 +1,7 @@
 Haxe File
   EXTERN_INTERFACE_DECLARATION
-    PsiJavaToken:extern('extern ')
+    EXTERN_KEY_WORD
+      PsiJavaToken:extern('extern ')
     PsiJavaToken:interface('interface')
     COMPONENT_NAME
       IDENTIFIER

--- a/testData/parsing/haxe/declarations/extern/Simple.txt
+++ b/testData/parsing/haxe/declarations/extern/Simple.txt
@@ -1,6 +1,7 @@
 Haxe File
   EXTERN_CLASS_DECLARATION
-    PsiJavaToken:extern('extern ')
+    EXTERN_KEY_WORD
+      PsiJavaToken:extern('extern ')
     PsiJavaToken:class('class')
     COMPONENT_NAME
       IDENTIFIER


### PR DESCRIPTION
use separate privateKeyWord and externKeyWord instead of externOrPrivate

I had to make changes to rules suggested by @EBatTiVo 

```
privateKeyword := 'private'
externKeyword := 'extern'
private externPrivate := externKeyword | privateKeyword
private privateExtern := privateKeyword | externKeyword
private externOrPrivate := privateKeyword | externKeyword | externPrivate | privateExtern
```

to

```
privateKeyWord ::= 'private'
externKeyWord ::= 'extern'

private externPrivate ::= externKeyWord privateKeyWord //use and instead of or
private privateExtern ::= privateKeyWord externKeyWord
//changed priority here so it won't get away with first possible case
private externOrPrivate ::= externPrivate | privateExtern | privateKeyWord | externKeyWord 
```