### PR TITLE
Revert complex checks in UsefulPsiTreeUtil.java/isWhitespaceOrComment, because HaxeASTFactory now produces PsiComment for comment tokens instead of producing PsiJavaToken for everything

### DIFF
--- a/src/common/com/intellij/plugins/haxe/util/UsefulPsiTreeUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/UsefulPsiTreeUtil.java
@@ -94,12 +94,6 @@ public class UsefulPsiTreeUtil {
   }
 
   public static boolean isWhitespaceOrComment(PsiElement element) {
-    if (element instanceof PsiJavaToken) {
-      PsiJavaToken psiJavaToken = (PsiJavaToken)element;
-      IElementType tokenType = psiJavaToken.getTokenType();
-      return tokenType.equals(HaxeTokenTypeSets.DOC_COMMENT) || tokenType.equals(HaxeTokenTypeSets.MML_COMMENT) || tokenType.equals(HaxeTokenTypeSets.MSL_COMMENT);
-    }
-
     return element instanceof PsiWhiteSpace || element instanceof PsiComment;
   }
 


### PR DESCRIPTION
Revert complex checks in UsefulPsiTreeUtil.java/isWhitespaceOrComment, because HaxeASTFactory now produces PsiComment for comment tokens instead of producing PsiJavaToken for everything