### PR TITLE
Static auto completion fix #262

### DIFF
--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -19,8 +19,8 @@ package com.intellij.plugins.haxe.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -34,7 +34,8 @@ import com.intellij.plugins.haxe.util.HaxeResolveUtil;
 import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.source.resolve.ResolveCache;
-import com.intellij.psi.impl.source.tree.*;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.intellij.psi.impl.source.tree.SourceUtil;
 import com.intellij.psi.infos.CandidateInfo;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.tree.IElementType;
@@ -709,7 +710,7 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
 
     boolean extern = haxeClass.isExtern();
 
-    for (HaxeNamedComponent namedComponent : HaxeResolveUtil.findNamedSubComponents(haxeClass)) {
+    for (HaxeNamedComponent namedComponent : HaxeResolveUtil.findNamedSubComponents(true, true, haxeClass)) {
       final boolean needFilter = filterByAccess && !namedComponent.isPublic();
       if ((extern || !needFilter) && namedComponent.isStatic() && namedComponent.getComponentName() != null) {
         suggestedVariants.add(namedComponent.getComponentName());

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -710,9 +710,12 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
 
     boolean extern = haxeClass.isExtern();
 
-    for (HaxeNamedComponent namedComponent : HaxeResolveUtil.findNamedSubComponents(true, true, haxeClass)) {
+    for (HaxeNamedComponent namedComponent : HaxeResolveUtil.findNamedSubComponents(true, false, haxeClass)) {
       final boolean needFilter = filterByAccess && !namedComponent.isPublic();
       if ((extern || !needFilter) && namedComponent.isStatic() && namedComponent.getComponentName() != null) {
+        if (namedComponent instanceof HaxeVarDeclaration) {
+          namedComponent = ((HaxeVarDeclaration)namedComponent).getVarDeclarationPart();
+        }
         suggestedVariants.add(namedComponent.getComponentName());
       }
     }

--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -251,12 +251,17 @@ public class HaxeResolveUtil {
 
   @NotNull
   public static List<HaxeNamedComponent> findNamedSubComponents(boolean unique, @NotNull HaxeClass... rootHaxeClasses) {
+    return findNamedSubComponents(unique, true, rootHaxeClasses);
+  }
+
+  @NotNull
+  public static List<HaxeNamedComponent> findNamedSubComponents(boolean unique, boolean extractVarDeclarationsPart, @NotNull HaxeClass... rootHaxeClasses) {
     final List<HaxeNamedComponent> unfilteredResult = new ArrayList<HaxeNamedComponent>();
     final LinkedList<HaxeClass> classes = new LinkedList<HaxeClass>();
     classes.addAll(Arrays.asList(rootHaxeClasses));
     while (!classes.isEmpty()) {
       final HaxeClass haxeClass = classes.pollFirst();
-      for (HaxeNamedComponent namedComponent : getNamedSubComponents(haxeClass)) {
+      for (HaxeNamedComponent namedComponent : getNamedSubComponents(haxeClass, extractVarDeclarationsPart)) {
         if (namedComponent.getName() != null) {
           unfilteredResult.add(namedComponent);
         }
@@ -294,6 +299,10 @@ public class HaxeResolveUtil {
   }
 
   public static List<HaxeNamedComponent> getNamedSubComponents(HaxeClass haxeClass) {
+    return getNamedSubComponents(haxeClass, true);
+  }
+
+  public static List<HaxeNamedComponent> getNamedSubComponents(HaxeClass haxeClass, boolean extractVarDeclarationsPart) {
     PsiElement body = null;
     final HaxeComponentType type = HaxeComponentType.typeOf(haxeClass);
     if (type == HaxeComponentType.CLASS) {
@@ -334,7 +343,7 @@ public class HaxeResolveUtil {
         // Variable declarations are named components, but don't have the
         // same Psi structure as most. So, go find the actual sub-element(s)
         // that are named (that themselves have COMPONENT_NAME sub-elements).
-        if (namedComponent instanceof HaxeVarDeclaration) {
+        if (extractVarDeclarationsPart && namedComponent instanceof HaxeVarDeclaration) {
           HaxeVarDeclaration varDeclaration = (HaxeVarDeclaration)namedComponent;
           result.add(varDeclaration.getVarDeclarationPart());
         }


### PR DESCRIPTION
Problems hide in extracting HaxeVarDefenition part (no field information except name) from HaxeVarDefenition instead returning original  HaxeVarDefenition (needs only for name and statc check) HaxeResolveUtil.getNamedSubComponents.

https://github.com/TiVo/intellij-haxe/issues/262