### PR TITLE
Fix262 show completion for static members not only for fully qualified names

### DIFF
--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -584,22 +584,17 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
     // TODO: This should use getName() instead of getQualifiedName(), but it isn't implemented properly and getName() NPEs.
     HaxeClassResolveResult result = null;
     HaxeClass haxeClass = null;
-    String qualifiedName = null;
     String name = null;
     if (leftReference != null) {
       result = leftReference.resolveHaxeClass();
       if (result != null) {
         haxeClass = result.getHaxeClass();
         if (haxeClass != null) {
-          qualifiedName = haxeClass.getQualifiedName();
-          final String[] split = qualifiedName.split("\\.");
-          if (split.length > 0) {
-            name = split[split.length - 1];
-          }
+          name = haxeClass.getName();
         }
       }
     }
-    if (leftReference != null && getParent() instanceof HaxeReference && qualifiedName != null && name != null && leftReference.getText().equals(
+    if (leftReference != null && getParent() instanceof HaxeReference && name != null && leftReference.getText().equals(
       name)) {
       addClassStaticMembersVariants(suggestedVariants, result.getHaxeClass(),
                                     !(leftReference instanceof HaxeThisExpression));
@@ -714,10 +709,11 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
     }
 
     boolean extern = haxeClass.isExtern();
+    boolean isEnum = haxeClass instanceof HaxeEnumDeclaration;
 
     for (HaxeNamedComponent namedComponent : HaxeResolveUtil.findNamedSubComponents(haxeClass)) {
       final boolean needFilter = filterByAccess && !namedComponent.isPublic();
-      if ((extern || !needFilter) && namedComponent.isStatic() && namedComponent.getComponentName() != null) {
+      if ((extern || !needFilter) && (namedComponent.isStatic() || isEnum) && namedComponent.getComponentName() != null) {
         suggestedVariants.add(namedComponent.getComponentName());
       }
     }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -585,16 +585,22 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
     HaxeClassResolveResult result = null;
     HaxeClass haxeClass = null;
     String qualifiedName = null;
+    String name = null;
     if (leftReference != null) {
       result = leftReference.resolveHaxeClass();
       if (result != null) {
         haxeClass = result.getHaxeClass();
         if (haxeClass != null) {
           qualifiedName = haxeClass.getQualifiedName();
+          final String[] split = qualifiedName.split("\\.");
+          if (split.length > 0) {
+            name = split[split.length - 1];
+          }
         }
       }
     }
-    if (leftReference != null && getParent() instanceof HaxeReference && qualifiedName != null && leftReference.getText().equals(qualifiedName)) {
+    if (leftReference != null && getParent() instanceof HaxeReference && qualifiedName != null && name != null && leftReference.getText().equals(
+      name)) {
       addClassStaticMembersVariants(suggestedVariants, result.getHaxeClass(),
                                     !(leftReference instanceof HaxeThisExpression));
       addChildClassVariants(suggestedVariants, result.getHaxeClass());

--- a/testData/completion/references/StaticMember.hx
+++ b/testData/completion/references/StaticMember.hx
@@ -1,9 +1,16 @@
-class StaticMethods {
+enum FooEnum
+{
+    FIRST;
+    SECOND;
+}
+
+class StaticMember {
     public static function foo() {}
+    public static var bar;
 }
 
 class Main {
     public static function main() {
-        StaticMethods.<caret>
+        StaticMember.<caret>
     }
 }

--- a/testData/completion/references/StaticMember.hx
+++ b/testData/completion/references/StaticMember.hx
@@ -1,0 +1,9 @@
+class StaticMethods {
+    public static function foo() {}
+}
+
+class Main {
+    public static function main() {
+        StaticMethods.<caret>
+    }
+}

--- a/testData/completion/references/StaticMember.txt
+++ b/testData/completion/references/StaticMember.txt
@@ -1,0 +1,2 @@
+BASIC 1 INCLUDES
+foo

--- a/testData/completion/references/StaticMember.txt
+++ b/testData/completion/references/StaticMember.txt
@@ -1,2 +1,4 @@
-BASIC 1 INCLUDES
+BASIC 3 INCLUDES
+FooEnum
 foo
+bar

--- a/testData/parsing/haxe/declarations/class/FullOfMacro.txt
+++ b/testData/parsing/haxe/declarations/class/FullOfMacro.txt
@@ -281,11 +281,9 @@ Haxe File
                 PsiJavaToken:true('true')
             PsiJavaToken:)(')')
           PsiJavaToken:)(')')
-    EXTERN_OR_PRIVATE
-      PsiJavaToken:extern('extern ')
-    EXTERN_OR_PRIVATE
-      PRIVATE_KEY_WORD
-        PsiJavaToken:private('private')
+    PsiJavaToken:extern('extern ')
+    PRIVATE_KEY_WORD
+      PsiJavaToken:private('private')
     PsiJavaToken:class('class')
     COMPONENT_NAME
       IDENTIFIER

--- a/testData/parsing/haxe/declarations/class/NativeRandom.txt
+++ b/testData/parsing/haxe/declarations/class/NativeRandom.txt
@@ -5,8 +5,7 @@ Haxe File
         SIMPLE_META
           FINAL_META
             PsiJavaToken:@:final('@:final')
-    EXTERN_OR_PRIVATE
-      PsiJavaToken:extern('extern ')
+    PsiJavaToken:extern('extern ')
     PsiJavaToken:class('class')
     COMPONENT_NAME
       IDENTIFIER
@@ -92,11 +91,9 @@ Haxe File
           PsiJavaToken:}('}')
     PsiJavaToken:}('}')
   EXTERN_CLASS_DECLARATION
-    EXTERN_OR_PRIVATE
-      PRIVATE_KEY_WORD
-        PsiJavaToken:private('private')
-    EXTERN_OR_PRIVATE
-      PsiJavaToken:extern('extern ')
+    PRIVATE_KEY_WORD
+      PsiJavaToken:private('private')
+    PsiJavaToken:extern('extern ')
     PsiJavaToken:class('class')
     COMPONENT_NAME
       IDENTIFIER

--- a/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
+++ b/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
@@ -162,4 +162,9 @@ public class ReferenceCompletionTest extends HaxeCompletionTestBase {
     doTestVariantsInner("TypedefOptionalField.txt");
   }
 
+  //https://github.com/TiVo/intellij-haxe/issues/262
+  public void testStaticMember() throws Throwable {
+    doTest();
+  }
+
 }


### PR DESCRIPTION
Merged both pull requests:
https://github.com/TiVo/intellij-haxe/pull/264 and 
https://github.com/TiVo/intellij-haxe/pull/265 to support both implemented functionality

@as3boyan: Fix enum and functions static autocompletion;
@romanmikhailov: Fix field static autocompletion;

Fix https://github.com/TiVo/intellij-haxe/issues/262