### PR TITLE
Align contents of the plugin jar files.  #239

### DIFF
--- a/.idea/artifacts/haxe.xml
+++ b/.idea/artifacts/haxe.xml
@@ -12,7 +12,7 @@
         <element id="archive" name="haxe.jar">
           <element id="module-output" name="intellij-haxe" />
         </element>
-        <element id="file-copy" path="$PROJECT_DIR$/src/com/intellij/plugins/haxe/runner/debugger/JavaProtocol.jar" />
+        <element id="module-output" name="hxcpp-debugger-protocol" />
       </element>
     </root>
   </artifact>

--- a/build.xml
+++ b/build.xml
@@ -8,46 +8,72 @@
 
     <!-- javac2 is an intellij ant task to wrap the java compiler and add
          support to .form files and @NotNull annotations, among others -->
-    <taskdef name="javac2" classname="com.intellij.ant.Javac2">
-        <classpath>
-            <pathelement location="${idea.ultimate.build}/lib/javac2.jar"/>
-            <pathelement location="${idea.ultimate.build}/lib/forms_rt.jar"/>
-            <pathelement location="${idea.ultimate.build}/lib/asm-all.jar"/>
-            <fileset dir="${idea.ultimate.build}/lib" includes="**/*.jar" />
-            <fileset dir="${idea.ultimate.build}/plugins" includes="**/**.jar" />
-        </classpath>
-    </taskdef>
+    <property name="javac2.home" value="${idea.ultimate.build}/lib"/>
+    <path id="javac2.classpath">
+        <pathelement location="${javac2.home}/javac2.jar"/>
+        <pathelement location="${javac2.home}/jdom.jar"/>
+        <pathelement location="${javac2.home}/asm-all.jar"/>
+        <pathelement location="${javac2.home}/jgoodies-forms.jar"/>
+    </path>
+    <taskdef name="javac2" classname="com.intellij.ant.Javac2" classpathref="javac2.classpath"/>
+    <taskdef name="instrumentIdeaExtensions" classname="com.intellij.ant.InstrumentIdeaExtensions" classpathref="javac2.classpath"/>
 
-    <target name="clean" description="clean up">
-        <delete dir="build" />
+    <!-- Put the subsystems in separate directories to deal with dependency issues.
+         Basically, jps-plugin can't be compiled into the same directory structure as
+         the rest of the plugin code. -->
+    <property name="build.output.directory" value="build"/>
+    <property name="jps.build.output.directory" value="${build.output.directory}/jps-plugin"/>
+    <property name="plugin.build.output.directory" value="${build.output.directory}/haxe"/>
+    <property name="common.build.output.directory" value="${build.output.directory}/common"/>
+
+    <target name="clean" description="Erase all build artifacts">
+        <delete dir="${build.output.directory}" />
     </target>
 
     <target name="init" depends="showIdeaBuild">
+        <echo level="warning">
+            Using IDEA release at: ${idea.ultimate.build}
+        </echo>
         <tstamp/>
-        <mkdir dir="build"/>
+        <mkdir dir="${build.output.directory}"/>
     </target>
 
+    <target name="compile" depends="clean,init,compile.common,compile.jps,compile.plugin" description="Compile Haxe Plugin Cleanly">
+    </target>
 
-
-    <target name="compile" depends="clean,init" description="Compile tests">
-        <echo level="warning">
-          Using IDEA release at: ${idea.ultimate.build}
-        </echo>
-
+    <target name="compile.jps" depends="compile.common" description="Compile JPS Runtime Support Incrementally">
+        <mkdir dir="${jps.build.output.directory}"/>
+        <property name="compiler.max.memory" value="700m"/>
         <javac2
-            destdir="build"
+            destdir="${jps.build.output.directory}"
             verbose="false"
             debug="true"
             source="1.6"
             target="1.6"
-            includeantruntime="false" >
+            fork="true"
+            includeantruntime="true" >
 
-            <src path="${version.specific.code.location}" />
-            <src path="src/common" />
-            <src path="src/icons" />
-            <src path="gen" />
+            <src path="jps-plugin/src"/>
+            <classpath>
+                <path location="${common.build.output.directory}"/>
+                <fileset dir="${idea.ultimate.build}/lib" includes="**/*.jar" />
+                <!-- Do NOT include the IJ plugins directory in the classpath
+                     when compiling jps. The compiler NPEs.-->
+            </classpath>
+        </javac2>
+    </target>
+
+    <target name="compile.common" description="Compile Haxe Plugin Incrementally">
+        <mkdir dir="${common.build.output.directory}"/>
+        <javac2
+            destdir="${common.build.output.directory}"
+            verbose="false"
+            debug="true"
+            source="1.6"
+            target="1.6"
+            includeantruntime="true" >
+
             <src path="common/src" />
-            <src path="hxcpp-debugger-protocol" />
             <classpath>
                 <fileset dir="${idea.ultimate.build}/lib" includes="**/*.jar" />
                 <fileset dir="${idea.ultimate.build}/plugins" includes="**/**.jar" />
@@ -56,16 +82,42 @@
 
     </target>
 
+    <target name="compile.plugin" description="Compile Haxe Plugin Incrementally">
+        <mkdir dir="${plugin.build.output.directory}"/>
+        <javac2
+            destdir="${plugin.build.output.directory}"
+            verbose="false"
+            debug="true"
+            source="1.6"
+            target="1.6"
+            includeantruntime="true" >
+
+            <src path="${version.specific.code.location}" />
+            <src path="src/common" />
+            <src path="src/icons" />
+            <src path="gen" />
+            <src path="hxcpp-debugger-protocol" />
+            <classpath>
+                <pathelement location="${common.build.output.directory}"/>
+                <fileset dir="${idea.ultimate.build}/lib" includes="**/*.jar" />
+                <fileset dir="${idea.ultimate.build}/plugins" includes="**/**.jar" />
+            </classpath>
+        </javac2>
+
+    </target>
+
     <target name="package" depends="compile,metainf" description="Generate JAR file">
-        <jar jarfile="intellij-haxe-${idea.version}.jar" update="true">
+        <jar jarfile="intellij-haxe-${idea.version}.jar" update="false">
             <fileset dir="resources" />
-            <fileset dir="build" includes="**/*.*" excludes="src/META-INF/*.*"/>
             <fileset dir="gen" includes="META-INF/*.*"/>
+            <fileset dir="grammar" includes="haxe.bnf"/>
             <fileset dir="common/src" includes="**/*.*" excludes="**/*.java"/>
-            <fileset dir="src/common" >
-              <include name="com/**"/>
-              <exclude name="**/*.java"/>
-            </fileset>
+            <fileset dir="src/common" includes="com/**" excludes="**/*.java, **/*.form, **/*.flex"/>
+            <fileset dir="${plugin.build.output.directory}" includes="**/*.*" excludes="src/META-INF/*.*"/>
+            <fileset dir="${common.build.output.directory}"/>
+            <fileset dir="${jps.build.output.directory}"/>
+            <fileset dir="jps-plugin/src/" includes="META-INF/services/**/*.*" />
+            <zipfileset includes="com/intellij/uiDesigner/core/*.class" src="${idea.ultimate.build}/lib/forms_rt.jar"/>
         </jar>
 
     </target>


### PR DESCRIPTION
Make all files present in the IDE build of the jar be present in the Ant builds.

This separates the compilation into three steps, includes files for
running UI forms, and includes the JPS plugin files which were missing.
It also removes some files that were included in the Ant build but were
not necessary.  Note that there are a couple of redundant files in the
wrong places and a Haxe source file that are included by mistake in
the IDE build, but are still not included in the Ant build.
Fixes issue https://github.com/tivo/intellij-haxe/issues/239