### PR TITLE
Introduce build constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,12 @@ out/
 .DS_Store
 .idea/
 .iml
-build/
-build_test/
+.project
+/build/
+/build_test/
 local-build-overrides.xml
 intellij-haxe*.jar
-gen/META-INF/
+/gen/META-INF/**
+/gen/com/intellij/plugins/haxe/build/**
+
+

--- a/.idea/ant.xml
+++ b/.idea/ant.xml
@@ -2,10 +2,11 @@
 <project version="4">
   <component name="AntConfiguration">
     <buildFile url="file://$PROJECT_DIR$/build-test.xml" />
-    <buildFile url="file://$PROJECT_DIR$/build.xml">
-      <executeOn event="beforeCompilation" target="metainf" />
+    <buildFile url="file://$PROJECT_DIR$/build.xml" />
+    <buildFile url="file://$PROJECT_DIR$/local-build-overrides.xml" />
+    <buildFile url="file://$PROJECT_DIR$/common.xml">
+      <executeOn event="beforeCompilation" target="generateTemplatedFiles" />
     </buildFile>
-    <buildFile url="file://$PROJECT_DIR$/common.xml" />
   </component>
 </project>
 

--- a/.idea/runConfigurations/Haxe.xml
+++ b/.idea/runConfigurations/Haxe.xml
@@ -12,9 +12,6 @@
     <RunnerSettings RunnerId="Run" />
     <ConfigurationWrapper RunnerId="Debug" />
     <ConfigurationWrapper RunnerId="Run" />
-    <method>
-      <option name="AntTarget" enabled="true" antfile="file://$PROJECT_DIR$/build.xml" target="metainf" />
-      <option name="Make" enabled="true" />
-    </method>
+    <method />
   </configuration>
 </component>

--- a/.idea/runConfigurations/Haxe_Tests.xml
+++ b/.idea/runConfigurations/Haxe_Tests.xml
@@ -29,9 +29,6 @@
     <ConfigurationWrapper RunnerId="Cover" />
     <ConfigurationWrapper RunnerId="Debug" />
     <ConfigurationWrapper RunnerId="Run" />
-    <method>
-      <option name="AntTarget" enabled="true" antfile="file://$PROJECT_DIR$/build-test.xml" target="metainf" />
-      <option name="Make" enabled="true" />
-    </method>
+    <method />
   </configuration>
 </component>

--- a/build-test.xml
+++ b/build-test.xml
@@ -45,7 +45,7 @@
         <mkdir dir="build_test"/>
     </target>
 
-    <target name="compile_test" depends="clean,init,metainf" description="Compile tests">
+    <target name="compile_test" depends="clean,init,generateTemplatedFiles" description="Compile tests">
 
         <!-- javac2 is an intellij ant task to wrap the java compiler and add
              support to .form files and @NotNull annotations, among others -->

--- a/build.xml
+++ b/build.xml
@@ -106,8 +106,8 @@
 
     </target>
 
-    <target name="package" depends="compile,metainf" description="Generate JAR file">
-        <jar jarfile="intellij-haxe-${idea.version}.jar" update="false">
+    <target name="package" depends="compile,generateTemplatedFiles" description="Generate JAR file">
+        <jar jarfile="intellij-haxe-${idea.version}.jar" update="true">
             <fileset dir="resources" />
             <fileset dir="gen" includes="META-INF/*.*"/>
             <fileset dir="grammar" includes="haxe.bnf"/>

--- a/common.xml
+++ b/common.xml
@@ -125,20 +125,38 @@
      choose not to include any version specific code -->
   <property name="version.specific.code.location" location="src/common" />
 
-  <!-- Show pertinent build information -->
+  <!-- Pull apart the build version into component pieces -->
 
-  <target name="showIdeaBuild" description="Show build information, including SDK and version data.">
-    <echo>Requested version is set to "${version}"</echo>
-    <echo>Using installed IDEA version of ${idea.sdk.version}</echo>
-    <echo>Using IDEA build at "${idea.ultimate.build}</echo>
-    <echo>Idea property file is ${plugin.properties.file}</echo>
-    <echo>Including version specific code from ${version.specific.code.location}</echo>
+  <script language="javascript">
+    <![CDATA[
+      var buildId = project.getProperty("idea.sdk.version");
+      var typeSep = buildId.indexOf("-");
+      var clSep = buildId.indexOf(".", typeSep + 1);
+      var bldSep = buildId.indexOf(".", clSep + 1);
+
+      var buildType   = buildId.slice(0, typeSep);
+      var codeLine    = buildId.slice(typeSep + 1, clSep);
+      var buildNumber = (bldSep >= 0 ? buildId.slice(clSep + 1, bldSep) : buildId.slice(clSep + 1));
+      var iterNumber  = (bldSep >= 0 ? buildId.slice(bldSep + 1) : 0);
+
+      project.setNewProperty("idea.sdk.type", buildType);
+      project.setNewProperty("idea.sdk.codeline", codeLine);
+      project.setNewProperty("idea.sdk.build.number", buildNumber);
+      project.setNewProperty("idea.sdk.iter.number", iterNumber);
+    ]]>
+  </script>
+
+  <target name="showParsedBuildId">
+    <echo>
+      Build ID is "${idea.sdk.version}"
+      Build type is "${idea.sdk.type}"
+      Build code line is "${idea.sdk.codeline}"
+      Build number is "${idea.sdk.build.number}"
+      Build iteration is "${idea.sdk.iter.number}"
+    </echo>
   </target>
 
 
-  <!-- Copy the plugin.xml and replace elements within it with version appropriate data.-->
-
-  <property name="intellij-haxe.metainf.directory" value="src/META-INF"/>
   <property name="plugin.autogen.warning">
 
     ==============================================================
@@ -146,13 +164,37 @@
     ==============================================================
 
     Warning!! This file is auto-generated.  Do NOT edit it directly.
-    The corresponding source file can be found at ${intellij-haxe.metainf.directory}.
+    The corresponding source file can be found in the src/... directory.
 
     ==============================================================
     W A R N I N G ! !      W A R N I N G ! !     W A R N I N G ! !
     ==============================================================
 
   </property>
+
+  <!-- Copy and update the build version data to the Java template -->
+
+  <target name="generateIdeaSdkIdentifer" description="Generate the identifiers for IdeaTarget.java">
+    <!-- Need to overwrite always.  Otherwise, copied files are newer and
+         won't be updated between build types (versions). -->
+    <property name="haxe.build.dir" value="com/intellij/plugins/haxe/build"/>
+    <property name="haxe.idea.sdk.identifier.file" value="IdeaSDKIdentifier.java"/>
+    <copy file="src/common/${haxe.build.dir}/${haxe.idea.sdk.identifier.file}.template"
+          tofile="gen/${haxe.build.dir}/${haxe.idea.sdk.identifier.file}" overwrite="true" verbose="true">
+      <filterset>
+        <filter token="idea.sdk.version" value="${idea.sdk.version}"/>
+        <filter token="idea.sdk.type" value="${idea.sdk.type}"/>
+        <filter token="idea.sdk.codeline" value="${idea.sdk.codeline}"/>
+        <filter token="idea.sdk.build.number" value="${idea.sdk.build.number}"/>
+        <filter token="idea.sdk.iter.number" value="${idea.sdk.iter.number}"/>
+        <filter token="replace.with.plugin.autogen.warning" value="${plugin.autogen.warning}"/>
+      </filterset>
+    </copy>
+  </target>
+
+  <!-- Copy the plugin.xml and replace elements within it with version appropriate data.-->
+
+  <property name="intellij-haxe.metainf.directory" value="src/META-INF"/>
   <target name="metainf" description="Copy and update META-INF files with version-specific information">
     <!-- Need to overwrite always.  Otherwise, copied files are newer and
          won't be updated between build types (versions). -->
@@ -166,6 +208,25 @@
       </filterset>
     </copy>
   </target>
+
+
+  <!-- Build all generated files -->
+
+  <target name="generateTemplatedFiles"
+          depends="metainf, generateIdeaSdkIdentifer"
+          description="Generates files from templates in the source tree."/>
+
+
+  <!-- Show pertinent build information -->
+
+  <target name="showIdeaBuild" description="Show build information, including SDK and version data.">
+    <echo>Requested version is set to "${version}"</echo>
+    <echo>Using installed IDEA version of ${idea.sdk.version}</echo>
+    <echo>Using IDEA build at "${idea.ultimate.build}"</echo>
+    <echo>Idea property file is ${plugin.properties.file}</echo>
+    <echo>Including version specific code from ${version.specific.code.location}</echo>
+  </target>
+
 
 
 

--- a/common.xml
+++ b/common.xml
@@ -137,12 +137,12 @@
       var buildType   = buildId.slice(0, typeSep);
       var codeLine    = buildId.slice(typeSep + 1, clSep);
       var buildNumber = (bldSep >= 0 ? buildId.slice(clSep + 1, bldSep) : buildId.slice(clSep + 1));
-      var iterNumber  = (bldSep >= 0 ? buildId.slice(bldSep + 1) : 0);
+      var patchNumber  = (bldSep >= 0 ? buildId.slice(bldSep + 1) : 0);
 
       project.setNewProperty("idea.sdk.type", buildType);
       project.setNewProperty("idea.sdk.codeline", codeLine);
       project.setNewProperty("idea.sdk.build.number", buildNumber);
-      project.setNewProperty("idea.sdk.iter.number", iterNumber);
+      project.setNewProperty("idea.sdk.patch.number", patchNumber);
     ]]>
   </script>
 
@@ -152,7 +152,7 @@
       Build type is "${idea.sdk.type}"
       Build code line is "${idea.sdk.codeline}"
       Build number is "${idea.sdk.build.number}"
-      Build iteration is "${idea.sdk.iter.number}"
+      Build patch is "${idea.sdk.patch.number}"
     </echo>
   </target>
 
@@ -186,7 +186,7 @@
         <filter token="idea.sdk.type" value="${idea.sdk.type}"/>
         <filter token="idea.sdk.codeline" value="${idea.sdk.codeline}"/>
         <filter token="idea.sdk.build.number" value="${idea.sdk.build.number}"/>
-        <filter token="idea.sdk.iter.number" value="${idea.sdk.iter.number}"/>
+        <filter token="idea.sdk.patch.number" value="${idea.sdk.patch.number}"/>
         <filter token="replace.with.plugin.autogen.warning" value="${plugin.autogen.warning}"/>
       </filterset>
     </copy>

--- a/src/common/com/intellij/plugins/haxe/build/IdeaSDKIdentifier.java.template
+++ b/src/common/com/intellij/plugins/haxe/build/IdeaSDKIdentifier.java.template
@@ -26,6 +26,6 @@ public class IdeaSDKIdentifier {
   public static final String BUILD_TYPE = "@idea.sdk.type@";
   public static final int BUILD_CODELINE = @idea.sdk.codeline@;
   public static final int BUILD_NUMBER = @idea.sdk.build.number@;
-  public static final int BUILD_ITERATION = @idea.sdk.iter.number@;
+  public static final int BUILD_PATCH = @idea.sdk.patch.number@;
 
 }

--- a/src/common/com/intellij/plugins/haxe/build/IdeaSDKIdentifier.java.template
+++ b/src/common/com/intellij/plugins/haxe/build/IdeaSDKIdentifier.java.template
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.build;
+
+/*
+@replace.with.plugin.autogen.warning@
+*/
+
+/**
+ * Created by ebishton on 4/19/15.
+ */
+public class IdeaSDKIdentifier {
+   // Populated by ant build constants.  See common.xml in the project root.
+  public static final String BUILD_IDENTIFIER = "@idea.sdk.version@";
+  public static final String BUILD_TYPE = "@idea.sdk.type@";
+  public static final int BUILD_CODELINE = @idea.sdk.codeline@;
+  public static final int BUILD_NUMBER = @idea.sdk.build.number@;
+  public static final int BUILD_ITERATION = @idea.sdk.iter.number@;
+
+}

--- a/src/common/com/intellij/plugins/haxe/build/IdeaTarget.java
+++ b/src/common/com/intellij/plugins/haxe/build/IdeaTarget.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.build;
+
+/**
+ * Created by ebishton on 4/19/15.
+ */
+public class IdeaTarget {
+
+  // Loads the string at compile-time from a templatized class.
+  public static final String SDK_VERSION_STRING = IdeaSDKIdentifier.BUILD_IDENTIFIER;
+  public static final String SDK_TYPE = IdeaSDKIdentifier.BUILD_TYPE;
+  public static final int SDK_CODELINE = IdeaSDKIdentifier.BUILD_CODELINE;
+  public static final int SDK_BUILD_NUMBER = IdeaSDKIdentifier.BUILD_NUMBER;
+  public static final int SDK_BUILD_ITERATION = IdeaSDKIdentifier.BUILD_ITERATION;
+
+  // Add new constants for specific requirements here.
+  // All of these should be boolean constants.  They will
+  // be used by the compiler to eliminate dead code, and to
+  // allow non-compatible code to exist in the same file.
+  //
+  // Always use the most generic of the compatibility strings possible.
+
+  public static final boolean IS_VERSION_13_COMPATIBLE = (SDK_CODELINE == 133 || SDK_CODELINE == 135);
+  public static final boolean IS_VERSION_13_0_COMPATIBLE = (SDK_CODELINE == 133);
+  public static final boolean IS_VERSION_13_1_COMPATIBLE = (SDK_CODELINE == 135);
+
+  public static final boolean IS_VERSION_14_COMPATIBLE = (SDK_CODELINE == 139 || SDK_CODELINE == 141);
+  public static final boolean IS_VERSION_14_0_COMPATIBLE = (SDK_CODELINE == 139);
+  public static final boolean IS_VERSION_14_1_COMPATIBLE = (SDK_CODELINE == 141);
+
+}

--- a/src/common/com/intellij/plugins/haxe/build/IdeaTarget.java
+++ b/src/common/com/intellij/plugins/haxe/build/IdeaTarget.java
@@ -23,7 +23,7 @@ public class IdeaTarget {
   public static final String SDK_TYPE = IdeaSDKIdentifier.BUILD_TYPE;
   public static final int SDK_CODELINE = IdeaSDKIdentifier.BUILD_CODELINE;
   public static final int SDK_BUILD_NUMBER = IdeaSDKIdentifier.BUILD_NUMBER;
-  public static final int SDK_BUILD_ITERATION = IdeaSDKIdentifier.BUILD_ITERATION;
+  public static final int SDK_BUILD_PATCH = IdeaSDKIdentifier.BUILD_PATCH;
 
   // Add new constants for specific requirements here.
   // All of these should be boolean constants.  They will


### PR DESCRIPTION
Adds a set of build constants that can be used to isolate code changes specific to the IDEA SDK version used to build the plugin.  In other words, we can use code like: `if (IS_IDEA_14_COMPATIBLE) { ...do IDEA 14 stuff... }` to isolate version differences.

The major portion of the changes are in the ant build files which parse the `build.txt` file and copy the data into the appropriate spot in the template file, creating the source file gen/.../build/IdeaSDKIdentifier.java that is used during compilation.

@as3boyan @sganapavarapu1 @yanhick - I would appreciate the review.  I know it's a bit complex.  Sorry about that, but it didn't really make sense to stage these changes in smaller chunks.