### PR TITLE
Class cast exception

### DIFF
--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeNamedElementImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeNamedElementImpl.java
@@ -57,8 +57,9 @@ public abstract class HaxeNamedElementImpl extends HaxePsiCompositeElementImpl i
       getNode().replaceChild(identifier.getNode(), identifierNew.getNode());
     }
 
-    if (getParent() instanceof HaxeClass) {
-      final HaxeFile haxeFile = (HaxeFile)getParent().getParent();
+    PsiElement parent = getParent();
+    if (parent instanceof HaxeClass && parent.getParent() instanceof HaxeClass) {
+      final HaxeFile haxeFile = (HaxeFile)parent.getParent();
       if (oldName != null && oldName.equals(FileUtil.getNameWithoutExtension(haxeFile.getName()))) {
         haxeFile.setName(newElementName + "." + FileUtilRt.getExtension(haxeFile.getName()));
       }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypeListPartPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypeListPartPsiMixinImpl.java
@@ -447,7 +447,8 @@ public class HaxeTypeListPartPsiMixinImpl extends HaxePsiCompositeElementImpl im
 
     @Nullable
     protected HaxeClass getResolvedDelegate() {
-      return (HaxeClass) getDelegate().resolve();
+      PsiElement elem = getDelegate().resolve();
+      return elem instanceof HaxeClass? (HaxeClass) elem : null;
     }
 
     //


### PR DESCRIPTION
1. https://ea.jetbrains.com/browser/ea_reports/837775
    * Product: IDEA 141.914
    * Action: $SelectAll
    * OS: Windows 8 / Java: Oracle 1.8.0_40
    * Date: 08.05.2015 08:42  
    * Log:
    ```
    java.lang.ClassCastException: com.intellij.psi.impl.source.JavaDummyHolder cannot be cast to com.intellij.plugins.haxe.lang.psi.HaxeFile
      at com.intellij.plugins.haxe.lang.psi.impl.HaxeNamedElementImpl.setName(HaxeNamedElementImpl.java:61)
      at com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxeNamedComponent.setName(AbstractHaxeNamedComponent.java:74)
      at com.intellij.refactoring.copy.CopyClassesHandler.copy(CopyClassesHandler.java:456)
      at com.intellij.refactoring.copy.CopyClassesHandler.doCopyClasses(CopyClassesHandler.java:356)
      at com.intellij.refactoring.copy.CopyClassesHandler$2$1.run(CopyClassesHandler.java:282)
      at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:931)
      at com.intellij.refactoring.copy.CopyClassesHandler$2.run(CopyClassesHandler.java:301)
      at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:124)
      at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:99)
      at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:85)
      at com.intellij.refactoring.copy.CopyClassesHandler.copyClassesImpl(CopyClassesHandler.java:305)
      at com.intellij.refactoring.copy.CopyClassesHandler.doCopy(CopyClassesHandler.java:229)
      at com.intellij.refactoring.copy.CopyHandler.doCopy(CopyHandler.java:55)
      at com.intellij.ide.CopyPasteDelegator$MyEditable.performDefaultPaste(CopyPasteDelegator.java:168)
      at com.intellij.ide.CopyPasteDelegator$MyEditable.performPaste(CopyPasteDelegator.java:131)
      at com.intellij.ide.actions.PasteAction.actionPerformed(PasteAction.java:42)
      at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher$3.performAction(IdeKeyEventDispatcher.java:586)
      at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.processAction(IdeKeyEventDispatcher.java:637)
      at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.inInitState(IdeKeyEventDispatcher.java:476)
      at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.dispatchKeyEvent(IdeKeyEventDispatcher.java:212)
      at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:538)
      at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:382)
      at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
      at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
      at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
      at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
      at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
      at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
    ```
2. HaxeGenericListPartImpl cannot be cast to HaxeClass
    ```
    com.intellij.plugins.haxe.lang.psi.impl.HaxeGenericListPartImpl cannot be cast to com.intellij.plugins.haxe.lang.psi.HaxeClass
    java.lang.ClassCastException: com.intellij.plugins.haxe.lang.psi.impl.HaxeGenericListPartImpl cannot be cast to com.intellij.plugins.haxe.lang.psi.HaxeClass
      at com.intellij.plugins.haxe.lang.psi.impl.HaxeTypeListPartPsiMixinImpl$HaxeClassDelegateForTypeChild.getResolvedDelegate(HaxeTypeListPartPsiMixinImpl.java:450)
      at com.intellij.plugins.haxe.lang.psi.impl.HaxeTypeListPartPsiMixinImpl$HaxeClassDelegateForTypeChild.getSuperTypes(HaxeTypeListPartPsiMixinImpl.java:603)
      at com.intellij.plugins.haxe.lang.psi.impl.HaxeTypeListPartPsiMixinImpl.getSuperTypes(HaxeTypeListPartPsiMixinImpl.java:355)
      at com.intellij.psi.util.MethodSignatureUtil.getSuperMethodSignatureSubstitutor(MethodSignatureUtil.java:305)
      at com.intellij.psi.util.MethodSignatureUtil.isSubsignature(MethodSignatureUtil.java:374)
      at com.intellij.psi.impl.search.MethodTextOccurrenceProcessor.processInexactReference(MethodTextOccurrenceProcessor.java:87)
      at com.intellij.psi.impl.search.MethodTextOccurrenceProcessor.a(MethodTextOccurrenceProcessor.java:67)
      at com.intellij.psi.impl.search.MethodTextOccurrenceProcessor.processTextOccurrence(MethodTextOccurrenceProcessor.java:47)
      at com.intellij.psi.impl.search.PsiSearchHelperImpl$17.execute(PsiSearchHelperImpl.java:765)
      at com.intellij.psi.impl.search.LowLevelSearchUtil.a(LowLevelSearchUtil.java:126)
      at com.intellij.psi.impl.search.LowLevelSearchUtil.processElementsContainingWordInElement(LowLevelSearchUtil.java:200)
      at com.intellij.psi.impl.search.PsiSearchHelperImpl$3$1.compute(PsiSearchHelperImpl.java:214)
      at com.intellij.psi.impl.search.PsiSearchHelperImpl$3$1.compute(PsiSearchHelperImpl.java:211)
      at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:884)
      at com.intellij.psi.impl.search.PsiSearchHelperImpl$3.process(PsiSearchHelperImpl.java:211)
      at com.intellij.psi.impl.search.PsiSearchHelperImpl$3.process(PsiSearchHelperImpl.java:208)
      at com.intellij.concurrency.JobLauncherImpl$2$1.run(JobLauncherImpl.java:142)
      at com.intellij.openapi.progress.impl.CoreProgressManager.a(CoreProgressManager.java:452)
      at com.intellij.openapi.progress.impl.CoreProgressManager.a(CoreProgressManager.java:449)
      at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:402)
      at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:54)
      at com.intellij.concurrency.JobLauncherImpl$2.run(JobLauncherImpl.java:136)
      at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1098)
      at com.intellij.concurrency.JobLauncherImpl.invokeConcurrentlyUnderProgress(JobLauncherImpl.java:152)
      at com.intellij.psi.impl.search.PsiSearchHelperImpl.processElementsWithWord(PsiSearchHelperImpl.java:196)
      at com.intellij.psi.impl.search.PsiSearchHelperImpl.b(PsiSearchHelperImpl.java:956)
      at com.intellij.psi.impl.search.PsiSearchHelperImpl.processRequests(PsiSearchHelperImpl.java:618)
      at com.intellij.psi.search.SearchRequestQuery.processResults(SearchRequestQuery.java:45)
      at com.intellij.util.AbstractQuery.forEach(AbstractQuery.java:75)
      at com.intellij.util.MergeQuery.processSubQuery(MergeQuery.java:84)
      at com.intellij.util.MergeQuery.forEach(MergeQuery.java:56)
      at com.intellij.util.UniqueResultsQuery.process(UniqueResultsQuery.java:66)
      at com.intellij.util.UniqueResultsQuery.forEach(UniqueResultsQuery.java:56)
      at com.intellij.util.UniqueResultsQuery.findAll(UniqueResultsQuery.java:78)
      at com.intellij.find.findUsages.JavaFindUsagesHandler.findReferencesToHighlight(JavaFindUsagesHandler.java:237)
      at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.getHighlightUsages(IdentifierHighlighterPass.java:138)
      at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.a(IdentifierHighlighterPass.java:167)
      at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.doCollectInformation(IdentifierHighlighterPass.java:106)
      at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:67)
      at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:438)
      at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1098)
      at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:429)
      at com.intellij.openapi.progress.impl.CoreProgressManager.a(CoreProgressManager.java:452)
      at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:402)
      at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:54)
      at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:426)
      at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:402)
      at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask.exec(JobLauncherImpl.java:202)
      at jsr166e.ForkJoinTask.doExec(ForkJoinTask.java:260)
      at jsr166e.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:858)
      at jsr166e.ForkJoinPool.scan(ForkJoinPool.java:1687)
      at jsr166e.ForkJoinPool.runWorker(ForkJoinPool.java:1642)
      at jsr166e.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:109)
    ```