### PR TITLE
Fix build dependencies to generate IdeaSDKIdentifier.java during norm…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -38,7 +38,7 @@
         <mkdir dir="${build.output.directory}"/>
     </target>
 
-    <target name="compile" depends="clean,init,compile.common,compile.jps,compile.plugin" description="Compile Haxe Plugin Cleanly">
+    <target name="compile" depends="clean,init,generateTemplatedFiles,compile.common,compile.jps,compile.plugin" description="Compile Haxe Plugin Cleanly">
     </target>
 
     <target name="compile.jps" depends="compile.common" description="Compile JPS Runtime Support Incrementally">


### PR DESCRIPTION
…al builds.  This was a very simple fix that I discovered when trying to build a new repository.  The issue never shows up if you build and run the tests before creating the distributable.

@Srikanth, can you please review.