### PR TITLE
Fix travis build (quick fix, see comment)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@ protocol:
 	./build-haxe-protocol.sh
 
 #Build and run the unit tests
-test: protocol
+test:
 	./travis.sh $(IDEA_VERSION)


### PR DESCRIPTION
It turns out the build issue was no related to the JDK version.

I was caused by the JavaProtocol.hx class compilation used to communicate with the debugger. This class is supposed to be built before building and running the tests but it was actually broken before (when Travis was still working) as seen here:
https://travis-ci.org/TiVo/intellij-haxe/jobs/64992186#L336

The consequence is that the code in ```hxcpp-debugger-protocol``` was used instead since previous (working) version of the generated code was committed.

12 days ago, Bryan fixed some code in the debugger github repo which made building JavaProtocol.hx work (Travis clone this repo as part of the build), as seen here (this is the first build which failed) :
https://travis-ci.org/TiVo/intellij-haxe/jobs/65490725#L335

The issue is that the generated Java code for JavaProtocol.hx is now incompatible with what HaxeDebugRunner.java expect, probably due to some change to hxjava and to the haxe compiler. I didn't investigate that part yet.

The quick-fix is to stop building JavaProtocol.hx for now, so you can resume building on Travis but we should also add some more tasks to fix this more long term, I don't know how yet.