### PR TITLE
Fix #323 revert mods in gen tree

### DIFF
--- a/gen/com/intellij/plugins/haxe/lang/psi/HaxeVarDeclaration.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/HaxeVarDeclaration.java
@@ -20,14 +20,10 @@
 package com.intellij.plugins.haxe.lang.psi;
 
 import java.util.List;
-
-import com.intellij.plugins.haxe.model.HaxeFieldModel;
-import com.intellij.plugins.haxe.model.HaxeMethodModel;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 
 public interface HaxeVarDeclaration extends HaxePsiField {
-  HaxeFieldModel getModel();
 
   @NotNull
   List<HaxeAutoBuildMacro> getAutoBuildMacroList();

--- a/gen/com/intellij/plugins/haxe/lang/psi/HaxeVarDeclarationPart.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/HaxeVarDeclarationPart.java
@@ -20,12 +20,11 @@
 package com.intellij.plugins.haxe.lang.psi;
 
 import java.util.List;
-
-import com.intellij.plugins.haxe.model.HaxeFieldModel;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 
 public interface HaxeVarDeclarationPart extends HaxePsiField {
+
   @NotNull
   HaxeComponentName getComponentName();
 

--- a/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeExpressionListImpl.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeExpressionListImpl.java
@@ -19,13 +19,14 @@
 // This is a generated file. Not intended for manual editing.
 package com.intellij.plugins.haxe.lang.psi.impl;
 
+import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
+import static com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes.*;
 import com.intellij.plugins.haxe.lang.psi.*;
-
-import java.util.List;
 
 public class HaxeExpressionListImpl extends HaxePsiCompositeElementImpl implements HaxeExpressionList {
 

--- a/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeVarDeclarationImpl.java
+++ b/gen/com/intellij/plugins/haxe/lang/psi/impl/HaxeVarDeclarationImpl.java
@@ -20,9 +20,6 @@
 package com.intellij.plugins.haxe.lang.psi.impl;
 
 import java.util.List;
-
-import com.intellij.plugins.haxe.model.HaxeFieldModel;
-import com.intellij.plugins.haxe.model.HaxeMethodModel;
 import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
@@ -40,11 +37,6 @@ public class HaxeVarDeclarationImpl extends HaxePsiFieldImpl implements HaxeVarD
   public void accept(@NotNull PsiElementVisitor visitor) {
     if (visitor instanceof HaxeVisitor) ((HaxeVisitor)visitor).visitVarDeclaration(this);
     else super.accept(visitor);
-  }
-
-  @Override
-  public HaxeFieldModel getModel() {
-    return new HaxeFieldModel(this);
   }
 
   @Override

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
@@ -104,7 +104,7 @@ class TypeTagChecker {
 
 class FieldChecker {
   public static void check(final HaxeVarDeclaration var, final AnnotationHolder holder) {
-    HaxeFieldModel field = var.getModel();
+    HaxeFieldModel field = new HaxeFieldModel(var);
     if (field.isProperty()) {
       checkProperty(field, holder);
     }

--- a/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
@@ -206,7 +206,7 @@ public class HaxeClassModel {
 
   public HaxeFieldModel getField(String name) {
     HaxeVarDeclaration name1 = (HaxeVarDeclaration)haxeClass.findHaxeFieldByName(name);
-    return name1 != null ? name1.getModel() : null;
+    return name1 != null ? new HaxeFieldModel(name1) : null;
   }
 
   public HaxeMethodModel getMethod(String name) {

--- a/src/common/com/intellij/plugins/haxe/model/HaxeMemberModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeMemberModel.java
@@ -90,7 +90,7 @@ abstract public class HaxeMemberModel {
 
   public static HaxeMemberModel fromPsi(PsiElement element) {
     if (element instanceof HaxeMethod) return ((HaxeMethod)element).getModel();
-    if (element instanceof HaxeVarDeclaration) return ((HaxeVarDeclaration)element).getModel();
+    if (element instanceof HaxeVarDeclaration) return new HaxeFieldModel((HaxeVarDeclaration)element);
     final PsiElement parent = element.getParent();
     return (parent != null) ? fromPsi(parent) : null;
   }


### PR DESCRIPTION
Regenerated the parser files.  Fixed the places that called HaxeVarDeclaration.getModel(), which has been removed.

@soywiz, @sganapavarapu1, Please review.
