### PR TITLE
Remove non std haxelib command 'list-path' dependency

### DIFF
--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibLibraryCache.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibLibraryCache.java
@@ -76,14 +76,22 @@ public final class HaxelibLibraryCache {
       // add haxelib classpath to lookup cache
       final List<String> pathCmdOutput = HaxelibCommandUtils.issueHaxelibCommand(sdk, pathCmdline);
       for (final String s : pathCmdOutput) {
-        if (s.startsWith("-")) continue; // skip entries that don't have haxelib path
-        final int tmpSeparator = s.lastIndexOf('/');
-        final int endSeparator = s.lastIndexOf('/', tmpSeparator-1);
-        final int beginSeparator = s.lastIndexOf(File.separatorChar, endSeparator - 1);
-        final String haxelibName = s.substring(beginSeparator+1, endSeparator);
-        final HaxeClasspath classpath = new HaxeClasspath();
-        classpath.add(new HaxelibItem(haxelibName, s));
-        myCache.add(new HaxelibLibraryEntry(haxelibName, classpath));
+        if (s.startsWith("-")) continue; // skip lines that don't contain haxelib path
+        try {
+          final int tmpSeparator = s.lastIndexOf('/');
+          final int endSeparator = s.lastIndexOf('/', tmpSeparator-1);
+          final int beginSeparator = s.lastIndexOf(File.separatorChar, endSeparator - 1);
+          final String haxelibName = s.substring(beginSeparator+1, endSeparator);
+          final HaxeClasspath classpath = new HaxeClasspath();
+          classpath.add(new HaxelibItem(haxelibName, s));
+          myCache.add(new HaxelibLibraryEntry(haxelibName, classpath));
+        }
+        catch (IndexOutOfBoundsException e) {
+          // defensive try-catch block to handle possible exceptions when 'haxelib path'
+          // output does not match above parsing expectations
+          // e.g. when haxelib path output order or format is changed (happened once),
+          //   or when platform specific (Windows OS) format errors occur
+        }
       }
     }
     /* END of code that should be moved to HaxelibUtils.getInstalledLibraries. */

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibLibraryCache.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibLibraryCache.java
@@ -24,6 +24,7 @@ import org.apache.log4j.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Hashtable;
@@ -58,36 +59,32 @@ public final class HaxelibLibraryCache {
     /* TODO: EMB Note: This block of code belongs in HaxelibUtils.getInstalledLibraries.
      *       I'm leaving it here for now, to simplify the merge, but really should be moved.
      */
-
-    /* 'haxelib' has been  enhanced to support 'list-path' command.
-     *  (Changes may not have made it out to Open Source yet.)
-     * Here, we're checking the output to see if the version of haxelib
-     * currently installed supports the new command.  If so, we'll
-     * use the new functionality (and save many seconds by not having to
-     * fork a new process for each installed library).
-     */
-    boolean isHaxelibListPathCmdSupported = true;
-    final List<String> haxelibCmdOutput = HaxelibCommandUtils.issueHaxelibCommand(sdk, "list-path");
-    if ((haxelibCmdOutput.size() < 1) || (haxelibCmdOutput.get(0).contains("Unknown command"))) {
-      isHaxelibListPathCmdSupported = false;
-    }
-    if (isHaxelibListPathCmdSupported) {
-        final List<String> installedHaxelibs = new ArrayList<String>();
-        // Initialize the internal cache with the list of libraries known to haxelib,
-        // using the haxelib path specified in the SDK.
-        for (String s : haxelibCmdOutput) {
-            // haxelib list-path output format is, library-name:version:install/path
-            final String[] haxelibProperties = s.split(":");
-            if (haxelibProperties.length < 3) continue; // avoid ArrayIndexOutOfBoundsException
-            // Note: when the class HaxelibItem is enhanced to support creating a new instance
-            // of it just from name... above line should be changed to '< 1'... also... below
-            // code should create only using element [0]... there's a TODO in HaxelibItem.java
-            installedHaxelibs.add(haxelibProperties[0]);
-            final HaxeClasspath classpath = new HaxeClasspath();
-            classpath.add(new HaxelibItem(haxelibProperties[0], haxelibProperties[2]));
-            myCache.add(new HaxelibLibraryEntry(haxelibProperties[0], classpath));
-        }
-        knownLibraries = new ConcurrentSkipListSet<String>(installedHaxelibs);
+    final List<String> listCmdOutput = HaxelibCommandUtils.issueHaxelibCommand(sdk, "list");
+    if ((listCmdOutput.size() > 0) && (! listCmdOutput.get(0).contains("Unknown command"))) {
+      final List<String> installedHaxelibs = new ArrayList<String>();
+      // add haxelib names as args for 'haxelib path' command
+      final String[] pathCmdline = new String[listCmdOutput.size()+1];
+      int index = 0;
+      pathCmdline[index++] = "path";
+      for (final String line : listCmdOutput) {
+        final String[] tokens = line.split(":");
+        pathCmdline[index++] = tokens[0];
+        installedHaxelibs.add(tokens[0]);
+      }
+      // update list of known haxelibs
+      knownLibraries = new ConcurrentSkipListSet<String>(installedHaxelibs);
+      // add haxelib classpath to lookup cache
+      final List<String> pathCmdOutput = HaxelibCommandUtils.issueHaxelibCommand(sdk, pathCmdline);
+      for (final String s : pathCmdOutput) {
+        if (s.startsWith("-")) continue; // skip entries that don't have haxelib path
+        final int tmpSeparator = s.lastIndexOf('/');
+        final int endSeparator = s.lastIndexOf('/', tmpSeparator-1);
+        final int beginSeparator = s.lastIndexOf(File.separatorChar, endSeparator - 1);
+        final String haxelibName = s.substring(beginSeparator+1, endSeparator);
+        final HaxeClasspath classpath = new HaxeClasspath();
+        classpath.add(new HaxelibItem(haxelibName, s));
+        myCache.add(new HaxelibLibraryEntry(haxelibName, classpath));
+      }
     }
     /* END of code that should be moved to HaxelibUtils.getInstalledLibraries. */
   }


### PR DESCRIPTION
This change will make it possible to initialize haxelib classpath lookup cache (in IDEA) for any user as it uses standard command supported universally.

Plugin is currently using 'haxelib list-path' command to initialize cache.

'list-path' is non-std extension made within TiVo code base of 'haxelib' fork.
That was not submitted to open source because we realized that 'haxelib path' supports multiple haxelibs' paths to be queried using single 'haxelib path' command by passing all those haxelib names on same command line, separated by white space.
So 'list-path' was not needed within haxelib - hence, reverted in TiVo fork of haxelib.
Yet, the plugin implementation was not updated to avoid checking for list-path.

This fix now uses 'haxelib list' to get list of known haxelibs and a single call to 'haxelib path' to get classpath for all those haxelibs.
This processes the outputs of above two commands, as needed, to initialize internal haxelib cache during IDE launch... for better performance.
Earlier implementation of cache initialization (that's dependent on 'list-path' command support) would only work in TiVo environment
i.e. in non-TiVo development environments, haxelib classpath lookup cache (in IDEA) was *not* initialized during IDE (plugin) launch.
This change will make it possible to initialize haxelib classpath lookup cache (in IDEA) for any user as it uses standard command supported universally.