### PR TITLE
Remove setting the line terminator during unit tests.

### DIFF
--- a/testSrc/com/intellij/plugins/haxe/lang/completion/HaxeCompletionTestBase.java
+++ b/testSrc/com/intellij/plugins/haxe/lang/completion/HaxeCompletionTestBase.java
@@ -59,9 +59,7 @@ public abstract class HaxeCompletionTestBase extends HaxeCodeInsightFixtureTestC
   }
 
   protected PsiFile configureFileByText(String fname, String text) {
-    String lineSeparator = LineSeparator.getSystemLineSeparator().getSeparatorString();
     PsiFile newFile = myFixture.configureByText(fname, text);
-    newFile.getVirtualFile().setDetectedLineSeparator(lineSeparator);
     return newFile;
   }
 


### PR DESCRIPTION
  It masked a bug in completion for the watch pane.