### PR TITLE
Remove "statics of" entries from the variables pane of the debug window.

### DIFF
--- a/src/13.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
+++ b/src/13.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
@@ -885,8 +885,16 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
                    (debugger.StringList)
                      message.params.__a[0];
                  addChildren(childrenList, stringList);
-                 node.addChildren(childrenList, false);
-                 addStaticChildren(node);
+                 if (true) {
+                   node.addChildren(childrenList, true);
+                 } else {
+                   // Note: Removed because it cluttered the variable list.
+                   //       It's a candidate for reinstatement, possibly with
+                   //       a control variable.
+                   node.addChildren(childrenList, false);
+                   // Add all statics to the list of variables.
+                   addStaticChildren(node);
+                 }
                }
                else {
                  DebugProcess.this.warn

--- a/src/14.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
+++ b/src/14.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
@@ -877,8 +877,16 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
                    (debugger.StringList)
                      message.params.__a[0];
                  addChildren(childrenList, stringList);
-                 node.addChildren(childrenList, false);
-                 addStaticChildren(node);
+                 if (true) {
+                   node.addChildren(childrenList, true);
+                 } else {
+                   // Note: Removed because it cluttered the variable list.
+                   //       It's a candidate for reinstatement, possibly with
+                   //       a control variable.
+                   node.addChildren(childrenList, false);
+                   // Add all statics to the list of variables.
+                   addStaticChildren(node);
+                 }
                }
                else {
                  DebugProcess.this.warn

--- a/src/14/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
+++ b/src/14/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
@@ -877,8 +877,16 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
                    (debugger.StringList)
                      message.params.__a[0];
                  addChildren(childrenList, stringList);
-                 node.addChildren(childrenList, false);
-                 addStaticChildren(node);
+                 if (true) {
+                   node.addChildren(childrenList, true);
+                 } else {
+                   // Note: Removed because it cluttered the variable list.
+                   //       It's a candidate for reinstatement, possibly with
+                   //       a control variable.
+                   node.addChildren(childrenList, false);
+                   // Add all statics to the list of variables.
+                   addStaticChildren(node);
+                 }
                }
                else {
                  DebugProcess.this.warn


### PR DESCRIPTION
Now that the debugger retrieves and displays static variables for a class as a subtree to the instance data, showing all statics in a program is not necessary and clutters the UI.