### PR TITLE
Better debugger error messages

### DIFF
--- a/src/13.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
+++ b/src/13.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
@@ -1110,10 +1110,10 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
 
         private void fromStructuredValue
           (debugger.StructuredValue structuredValue) {
-          if (structuredValue.index == 0) {
+          if (structuredValue.index == 0) {  // Elided
             mExpression = (String)structuredValue.params.__a[1];
           }
-          else if (structuredValue.index == 1) {
+          else if (structuredValue.index == 1) {  // Single
             debugger.StructuredValueType type =
               (debugger.StructuredValueType)
                 structuredValue.params.__a[0];
@@ -1121,9 +1121,9 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
               structuredValue.params.__a[1];
             mIcon = AllIcons.Debugger.Value;
             mType = getTypeString(type);
-            mValue = value;
+            mValue = stripErrorAdornments(value);
           }
-          else if (structuredValue.index == 2) {
+          else if (structuredValue.index == 2) {  // List
             debugger.StructuredValueListType type =
               (debugger.StructuredValueListType)
                 structuredValue.params.__a[0];
@@ -1214,7 +1214,10 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
         }
 
         private String getErrorString(debugger.Message debugMessage) {
-          String message = debugMessage.toString();
+          return stripErrorAdornments(debugMessage.toString());
+        }
+
+        private String stripErrorAdornments(String message) {
 
           // Strip the enumeration text.
           Pattern wrapperPattern = Pattern.compile("ErrorEvaluatingExpression\\((.*)\\)", Pattern.DOTALL);

--- a/src/13.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
+++ b/src/13.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
@@ -74,6 +74,8 @@ import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Vector;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author: Fedor.Korotkov
@@ -1088,7 +1090,7 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
                  else {
                    mIcon = AllIcons.General.Error;
                    mValue = mType = "<Unavailable - " +
-                                    message.toString() + ">";
+                                    getErrorString(message) + ">";
                  }
 
                  // If fromStructuredValue contained a list, the nodes
@@ -1209,6 +1211,23 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
           else {
             return "<Unavailable>";
           }
+        }
+
+        private String getErrorString(debugger.Message debugMessage) {
+          String message = debugMessage.toString();
+
+          // Strip the enumeration text.
+          Pattern wrapperPattern = Pattern.compile("ErrorEvaluatingExpression\\((.*)\\)", Pattern.DOTALL);
+          Matcher m = wrapperPattern.matcher(message);
+          String description = m.matches() ? m.group(1) : message;
+
+          // Strip the call stack.
+          final String callStackMarker = "\nCalled from ";
+          if (description.contains(callStackMarker)) {
+            description = description.substring(0, description.indexOf(callStackMarker));
+          }
+
+          return description;
         }
 
         private String mName;

--- a/src/14.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
+++ b/src/14.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
@@ -74,6 +74,8 @@ import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Vector;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author: Fedor.Korotkov
@@ -1080,7 +1082,7 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
                  else {
                    mIcon = AllIcons.General.Error;
                    mValue = mType = "<Unavailable - " +
-                                    message.toString() + ">";
+                                    getErrorString(message) + ">";
                  }
 
                  // If fromStructuredValue contained a list, the nodes
@@ -1201,6 +1203,23 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
           else {
             return "<Unavailable>";
           }
+        }
+
+        private String getErrorString(debugger.Message debugMessage) {
+          String message = debugMessage.toString();
+
+          // Strip the enumeration text.
+          Pattern wrapperPattern = Pattern.compile("ErrorEvaluatingExpression\\((.*)\\)", Pattern.DOTALL);
+          Matcher m = wrapperPattern.matcher(message);
+          String description = m.matches() ? m.group(1) : message;
+
+          // Strip the call stack.
+          final String callStackMarker = "\nCalled from ";
+          if (description.contains(callStackMarker)) {
+            description = description.substring(0, description.indexOf(callStackMarker));
+          }
+
+          return description;
         }
 
         private String mName;

--- a/src/14.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
+++ b/src/14.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
@@ -1102,10 +1102,10 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
 
         private void fromStructuredValue
           (debugger.StructuredValue structuredValue) {
-          if (structuredValue.index == 0) {
+          if (structuredValue.index == 0) {  // Elided
             mExpression = (String)structuredValue.params.__a[1];
           }
-          else if (structuredValue.index == 1) {
+          else if (structuredValue.index == 1) {  // Single
             debugger.StructuredValueType type =
               (debugger.StructuredValueType)
                 structuredValue.params.__a[0];
@@ -1113,9 +1113,9 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
               structuredValue.params.__a[1];
             mIcon = AllIcons.Debugger.Value;
             mType = getTypeString(type);
-            mValue = value;
+            mValue = stripErrorAdornments(value);
           }
-          else if (structuredValue.index == 2) {
+          else if (structuredValue.index == 2) {  // List
             debugger.StructuredValueListType type =
               (debugger.StructuredValueListType)
                 structuredValue.params.__a[0];
@@ -1206,7 +1206,10 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
         }
 
         private String getErrorString(debugger.Message debugMessage) {
-          String message = debugMessage.toString();
+          return stripErrorAdornments(debugMessage.toString());
+        }
+
+        private String stripErrorAdornments(String message) {
 
           // Strip the enumeration text.
           Pattern wrapperPattern = Pattern.compile("ErrorEvaluatingExpression\\((.*)\\)", Pattern.DOTALL);

--- a/src/14/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
+++ b/src/14/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
@@ -74,6 +74,8 @@ import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Vector;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author: Fedor.Korotkov
@@ -1080,7 +1082,7 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
                  else {
                    mIcon = AllIcons.General.Error;
                    mValue = mType = "<Unavailable - " +
-                                    message.toString() + ">";
+                                    getErrorString(message) + ">";
                  }
 
                  // If fromStructuredValue contained a list, the nodes
@@ -1201,6 +1203,23 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
           else {
             return "<Unavailable>";
           }
+        }
+
+        private String getErrorString(debugger.Message debugMessage) {
+          String message = debugMessage.toString();
+
+          // Strip the enumeration text.
+          Pattern wrapperPattern = Pattern.compile("ErrorEvaluatingExpression\\((.*)\\)", Pattern.DOTALL);
+          Matcher m = wrapperPattern.matcher(message);
+          String description = m.matches() ? m.group(1) : message;
+
+          // Strip the call stack.
+          final String callStackMarker = "\nCalled from ";
+          if (description.contains(callStackMarker)) {
+            description = description.substring(0, description.indexOf(callStackMarker));
+          }
+
+          return description;
         }
 
         private String mName;

--- a/src/14/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
+++ b/src/14/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
@@ -1102,10 +1102,10 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
 
         private void fromStructuredValue
           (debugger.StructuredValue structuredValue) {
-          if (structuredValue.index == 0) {
+          if (structuredValue.index == 0) {  // Elided
             mExpression = (String)structuredValue.params.__a[1];
           }
-          else if (structuredValue.index == 1) {
+          else if (structuredValue.index == 1) {  // Single
             debugger.StructuredValueType type =
               (debugger.StructuredValueType)
                 structuredValue.params.__a[0];
@@ -1113,9 +1113,9 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
               structuredValue.params.__a[1];
             mIcon = AllIcons.Debugger.Value;
             mType = getTypeString(type);
-            mValue = value;
+            mValue = stripErrorAdornments(value);
           }
-          else if (structuredValue.index == 2) {
+          else if (structuredValue.index == 2) {  // List
             debugger.StructuredValueListType type =
               (debugger.StructuredValueListType)
                 structuredValue.params.__a[0];
@@ -1206,7 +1206,10 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
         }
 
         private String getErrorString(debugger.Message debugMessage) {
-          String message = debugMessage.toString();
+          return stripErrorAdornments(debugMessage.toString());
+        }
+
+        private String stripErrorAdornments(String message) {
 
           // Strip the enumeration text.
           Pattern wrapperPattern = Pattern.compile("ErrorEvaluatingExpression\\((.*)\\)", Pattern.DOTALL);


### PR DESCRIPTION
Cleans up debugger error messages when displayed in the debugger's variable pane.  This strips the ExpressionEvaluationError prefix and the call stack, if present.