### PR TITLE
Debugger File Selection Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ script: make test
 env:
     - IDEA_VERSION=13.1.6
     - IDEA_VERSION=14.0.4
-    - IDEA_VERSION=14.1.1
+    - IDEA_VERSION=14.1.4
 notifications:
   email: false

--- a/common/src/com/intellij/plugins/haxe/config/HaxeTarget.java
+++ b/common/src/com/intellij/plugins/haxe/config/HaxeTarget.java
@@ -20,6 +20,7 @@ package com.intellij.plugins.haxe.config;
 import com.intellij.plugins.haxe.HaxeCommonBundle;
 import com.intellij.util.SystemProperties;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
@@ -106,5 +107,26 @@ public enum HaxeTarget {
   @Override
   public String toString() {
     return description;
+  }
+
+  /**
+   * Match the string against the compiler's argument/parameter/flag for the
+   * target output.
+   *
+   * @param compilerTargetArgument - string to compare, e.g. '-js', '-neko'
+   * @return The target matching the flag, or null, if not found.
+   */
+  @Nullable
+  public static HaxeTarget matchOutputTarget(String compilerTargetArgument) {
+    for (HaxeTarget t : HaxeTarget.values()) {
+      if (t.getCompilerFlag().equals(compilerTargetArgument)) {
+        return t;
+      }
+    }
+    // as3 is an old case.
+    if ("-as3".equals(compilerTargetArgument)) {
+      return HaxeTarget.JAVA_SCRIPT;
+    }
+    return null;
   }
 }

--- a/common/src/com/intellij/plugins/haxe/config/HaxeTarget.java
+++ b/common/src/com/intellij/plugins/haxe/config/HaxeTarget.java
@@ -125,7 +125,7 @@ public enum HaxeTarget {
     }
     // as3 is an old case.
     if ("-as3".equals(compilerTargetArgument)) {
-      return HaxeTarget.JAVA_SCRIPT;
+      return HaxeTarget.FLASH;
     }
     return null;
   }

--- a/common/src/com/intellij/plugins/haxe/config/NMETarget.java
+++ b/common/src/com/intellij/plugins/haxe/config/NMETarget.java
@@ -25,24 +25,37 @@ import javax.swing.*;
  * @author: Fedor.Korotkov
  */
 public enum NMETarget {
-  IOS("iOS", "ios", "-simulator"),
-  ANDROID("Android", "android"),
-  WEBOS("webOS", "webos"),
-  BLACKBERRY("BlackBerry", "blackberry"),
-  WINDOWS("Windows", "windows"),
-  MAC("Mac OS", "mac"),
-  LINUX("Linux", "linux"),
-  LINUX64("Linux 64", "linux", "-64"),
-  FLASH("Flash", "flash"),
-  HTML5("HTML5", "html5"),
-  NEKO("Neko", "neko");
+
+  // The HaxeTarget values declared here are the most obvious intention.
+  // They may not be correct.  They follow the mapping that the lime command
+  // does when invoked for a target OS.  They are used by the classpath generator
+  // the create the implicit classpath that the Haxe compiler uses.
+  // This may lead to the wrong source file being presented when debugging,
+  // but it's a definite step up from showing the interface file.
+  // Note that the HaxeTarget is only used for IDEA's convenience and is not
+  // passed to the compiler (lime) command, while the flags (third and later
+  // arguments) are passed to the compiler.
+
+  IOS("iOS", HaxeTarget.NEKO, "ios", "-simulator"),
+  ANDROID("Android", HaxeTarget.NEKO, "android"),
+  WEBOS("webOS", HaxeTarget.NEKO, "webos"),
+  BLACKBERRY("BlackBerry", HaxeTarget.NEKO, "blackberry"),
+  WINDOWS("Windows", HaxeTarget.NEKO, "windows"),
+  MAC("Mac OS", HaxeTarget.NEKO, "mac"),
+  LINUX("Linux", HaxeTarget.NEKO, "linux"),
+  LINUX64("Linux 64", HaxeTarget.NEKO,  "linux", "-64"),
+  FLASH("Flash", HaxeTarget.FLASH, "flash"),
+  HTML5("HTML5", HaxeTarget.JAVA_SCRIPT, "html5"),
+  NEKO("Neko", HaxeTarget.NEKO, "neko");
 
   private final String[] flags;
   private final String description;
+  private final HaxeTarget outputTarget;
 
-  NMETarget(String description, String... flags) {
+  NMETarget(String description, HaxeTarget target, String... flags) {
     this.flags = flags;
     this.description = description;
+    this.outputTarget = target;
   }
 
   public String getTargetFlag() {
@@ -52,6 +65,8 @@ public enum NMETarget {
   public String[] getFlags() {
     return flags;
   }
+
+  public HaxeTarget getOutputTarget() { return outputTarget; }
 
   public static void initCombo(@NotNull DefaultComboBoxModel comboBoxModel) {
     for (NMETarget target : NMETarget.values()) {

--- a/common/src/com/intellij/plugins/haxe/config/OpenFLTarget.java
+++ b/common/src/com/intellij/plugins/haxe/config/OpenFLTarget.java
@@ -25,26 +25,38 @@ import javax.swing.*;
  * @author: Fedor.Korotkov
  */
 public enum OpenFLTarget {
-  IOS("iOS", "ios", "-simulator"),
-  ANDROID("Android", "android"),
-  WEBOS("webOS", "webos"),
-  BLACKBERRY("BlackBerry", "blackberry"),
-  WINDOWS("Windows", "windows"),
-  MAC("Mac OS", "mac"),
-  LINUX("Linux", "linux"),
-  LINUX64("Linux 64", "linux", "-64"),
-  FLASH("Flash", "flash"),
-  HTML5("HTML5", "html5"),
-  NEKO("Neko", "neko"),
-  TIZEN("Tizen", "tizen"),
-  EMSCRIPTEN("Emscripten", "emscripten");
+
+  // This mapping of the target to output target is the most likely scenario
+  // and is mapped according to the lime templates.  (In other words,
+  // this is what target lime will pick for you when you select an
+  // OS target.)  This may end up being incorrect, but it's normally
+  // correct when degugging and is a lot better than being presented
+  // the interface file.
+  // Note that the HaxeTarget is only used for IDEA's convenience and is not
+  // passed to the compiler (lime) command, while the flags (third and later
+  // arguments) are passed to the compiler.
+  IOS("iOS", HaxeTarget.CPP, "ios", "-simulator"),
+  ANDROID("Android", HaxeTarget.CPP, "android"),
+  WEBOS("webOS", HaxeTarget.CPP, "webos"),
+  BLACKBERRY("BlackBerry", HaxeTarget.CPP, "blackberry"),
+  WINDOWS("Windows", HaxeTarget.CPP, "windows"),
+  MAC("Mac OS", HaxeTarget.CPP, "mac"),
+  LINUX("Linux", HaxeTarget.CPP, "linux"),
+  LINUX64("Linux 64", HaxeTarget.CPP, "linux", "-64"),
+  FLASH("Flash", HaxeTarget.FLASH, "flash"),
+  HTML5("HTML5", HaxeTarget.JAVA_SCRIPT, "html5"),
+  NEKO("Neko", HaxeTarget.NEKO, "neko"),
+  TIZEN("Tizen", HaxeTarget.CPP, "tizen"),
+  EMSCRIPTEN("Emscripten", HaxeTarget.CPP, "emscripten");
 
   private final String[] flags;
   private final String description;
+  private final HaxeTarget outputTarget;
 
-  OpenFLTarget(String description, String... flags) {
+  OpenFLTarget(String description, HaxeTarget target, String... flags) {
     this.flags = flags;
     this.description = description;
+    this.outputTarget = target;
   }
 
   public String getTargetFlag() {
@@ -53,6 +65,10 @@ public enum OpenFLTarget {
 
   public String[] getFlags() {
     return flags;
+  }
+
+  public HaxeTarget getOutputTarget() {
+    return outputTarget;
   }
 
   public static void initCombo(@NotNull DefaultComboBoxModel comboBoxModel) {

--- a/src/13.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
+++ b/src/13.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
@@ -38,12 +38,14 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VFileProperty;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.plugins.haxe.HaxeBundle;
 import com.intellij.plugins.haxe.config.HaxeTarget;
 import com.intellij.plugins.haxe.config.NMETarget;
 import com.intellij.plugins.haxe.config.OpenFLTarget;
+import com.intellij.plugins.haxe.haxelib.HaxelibClasspathUtils;
 import com.intellij.plugins.haxe.ide.module.HaxeModuleSettings;
 import com.intellij.plugins.haxe.runner.HaxeApplicationConfiguration;
 import com.intellij.plugins.haxe.runner.NMERunningState;
@@ -65,6 +67,7 @@ import com.intellij.xdebugger.evaluation.XDebuggerEvaluator;
 import com.intellij.xdebugger.frame.*;
 import com.intellij.xdebugger.impl.XSourcePositionImpl;
 import com.intellij.xdebugger.impl.ui.tree.nodes.XValueNodeImpl;
+import gnu.trove.THashSet;
 import haxe.root.JavaProtocol;
 import org.jetbrains.annotations.NotNull;
 
@@ -792,6 +795,8 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
         mClassAndFunctionName =
           ((String)frameList.params.__a[2] + "." +
            (String)frameList.params.__a[3]);
+        VirtualFile file = null;
+
         String fileName = VfsUtil.extractFileName(mFileName);
         if (fileName == null) {
           fileName = mFileName;
@@ -804,18 +809,35 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
             (project, fileName,
              GlobalSearchScope.allScope(project));
         }
-        VirtualFile file = null;
+
+        java.util.Collection<VirtualFile> matches = new THashSet<VirtualFile>();
         if (!files.isEmpty()) {
           for (VirtualFile f : files) {
-            if (f.getPath() == mFileName) {
-              file = f;
-              break;
+            if (f.getPath().endsWith(mFileName)) {
+              matches.add(f);
             }
           }
-          if (file == null) {
-            file = files.iterator().next();
-          }
         }
+        if (matches.isEmpty()) {
+          // If we don't have a match yet, then walk the classpath looking for
+          // an appropriate file.
+          file = HaxelibClasspathUtils.findFileOnClasspath(module, mFileName);
+        } else if (matches.size() == 1) {
+          // Got one.  If it's a good file, keep it.  Otherwise, try to pick it
+          // out of the classpath.
+          VirtualFile possible = matches.iterator().next();
+          file = possible.isValid() ? possible : HaxelibClasspathUtils.findFileOnClasspath(module, possible.toString());
+        } else {
+          // Too many matches. Get the first that occurs on the classpath.
+          file = HaxelibClasspathUtils.findFirstFileOnClasspath(module, matches);
+        }
+
+        // Now, work around the fact that IDEA treats symlinks as separate files.
+        // XXX: This should be controlled via an UI option.
+        if (null != file && file.is(VFileProperty.SYMLINK)) {
+          file = file.getCanonicalFile();
+        }
+
         mSourcePosition =
           XSourcePositionImpl.create(file, mLineNumber - 1);
       }

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibClasspathUtils.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibClasspathUtils.java
@@ -18,6 +18,7 @@
 package com.intellij.plugins.haxe.haxelib;
 
 import com.google.common.base.Joiner;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
@@ -29,9 +30,13 @@ import com.intellij.openapi.roots.RootProvider;
 import com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.plugins.haxe.config.HaxeTarget;
 import com.intellij.plugins.haxe.hxml.HXMLFileType;
 import com.intellij.plugins.haxe.hxml.psi.HXMLClasspath;
+import com.intellij.plugins.haxe.ide.module.HaxeModuleSettings;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiFileFactory;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -40,13 +45,12 @@ import com.intellij.psi.xml.XmlFile;
 import com.intellij.psi.xml.XmlTag;
 import org.apache.log4j.Level;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.io.LocalFileFinder;
+import com.intellij.util.io.URLUtil;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 /**
  * Static interface to haxelib class path functionality.
@@ -54,9 +58,14 @@ import java.util.List;
 public class HaxelibClasspathUtils {
 
   static Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxelibClasspathUtils");
-  {
+  static {
     LOG.setLevel(Level.DEBUG);
   }
+
+  /** Old environment variable name for the Haxe standard library location. */
+  final public static String HAXE_LIBRARY_PATH = "HAXE_LIBRARY_PATH";
+  /** Modern environment variable name for the Haxe standard library location. */
+  final public static String HAXE_STD_PATH = "HAXE_STD_PATH";
 
   /**
    * Gets the libraries specified for the IDEA project; source paths and
@@ -210,6 +219,63 @@ public class HaxelibClasspathUtils {
     HaxeClasspath moduleClasspath = loadClasspathFrom(libraryTable);
     rootModel.dispose();    // MUST dispose of the model.
     return moduleClasspath;
+  }
+
+  /**
+   * Get the classpath that the compiler will use without it being specified.
+   *
+   * @param module - the module to be compiled.
+   * @return HaxeClasspath according to the module compilation options.
+   */
+  @NotNull
+  public static HaxeClasspath getImplicitClassPath(@NotNull Module module) {
+
+    // Figure out which target is being compiled to, because that tells us
+    // which backend implementation to use on the classpath.
+    HaxeModuleSettings settings = HaxeModuleSettings.getInstance(module);
+    HaxeTarget target = settings.getCompilationTarget();
+    String targetFlag = target.getFlag();
+
+    // Find the standard library.
+    String libraryPath = System.getenv(HAXE_STD_PATH);
+    if (null == libraryPath) {
+      // Back off to the old name if the modern one isn't found.
+      libraryPath = System.getenv(HAXE_LIBRARY_PATH);
+    }
+    if (null == libraryPath) {
+      return HaxeClasspath.EMPTY_CLASSPATH;
+    }
+
+    HaxeClasspath cp = new HaxeClasspath();
+
+    if (null != targetFlag) {
+      cp.add(new HaxeClasspathEntry("Std library target implementation",
+                                    libraryPath + File.separator + targetFlag +
+                                      File.separator + "_std"));
+    }
+    cp.add(new HaxeClasspathEntry("Standard Library", libraryPath));
+    return cp;
+  }
+
+
+  /**
+   * Get the complete classpath for a module, including implicit paths and
+   * all of the paths from the project and SDK.  Must be run inside of a
+   * read action.
+   *
+   * @param module to look up haxelib for.
+   * @return a (possibly empty) collection of classpaths.  These should
+   *         be properly ordered and are unique; duplicates occurring
+   *         later in the list are removed.
+   */
+  @NotNull
+  public static HaxeClasspath getFullClasspath(@NotNull Module module) {
+    HaxeClasspath classpath = getImplicitClassPath(module);
+    classpath.addAll(getModuleClasspath(module));
+    classpath.addAll(getProjectLibraryClasspath(module.getProject()));
+    // This grabs either the module's SDK, or the inherited one, if any.
+    classpath.addAll(getSdkClasspath(ModuleRootManager.getInstance(module).getSdk()));
+    return classpath;
   }
 
 
@@ -386,5 +452,135 @@ public class HaxelibClasspathUtils {
     return haxelibNewItems;
   }
 
+  /**
+   * Finds the first file on the classpath having the given name or relative path.
+   * This is attempting to emulate what the compiler would do.
+   *
+   * @param module - Module from which to gather the classpath.
+   * @param filePath - filePath name or relative path.
+   * @return a VirtualFile if found, or null otherwise.
+   */
+  @Nullable
+  public static VirtualFile findFileOnClasspath(@NotNull final Module module, @NotNull final String filePath) {
+    if (filePath.isEmpty()) {
+      return null;
+    }
+
+    return ApplicationManager.getApplication().runReadAction(new Computable<VirtualFile>() {
+      @Override
+      public VirtualFile compute() {
+        final String fixedPath = null == VirtualFileManager.extractProtocol(filePath)
+                                  ? VirtualFileManager.constructUrl(URLUtil.FILE_PROTOCOL, filePath)
+                                  : filePath;
+        VirtualFile found = VirtualFileManager.getInstance().findFileByUrl(fixedPath);
+        if (null == found) {
+          found = findFileOnOneClasspath(getImplicitClassPath(module), filePath);
+        }
+        if (null == found) {
+          found = findFileOnOneClasspath(getModuleClasspath(module), filePath);
+        }
+        if (null == found) {
+          found = findFileOnOneClasspath(getProjectLibraryClasspath(module.getProject()), filePath);
+        }
+        if (null == found) {
+          // This grabs either the module's SDK, or the inherited one, if any.
+          found = findFileOnOneClasspath(getSdkClasspath(ModuleRootManager.getInstance(module).getSdk()), filePath);
+        }
+        return found;
+      }
+    });
+  }
+
+  /**
+   * Workhorse for findFileOnClasspath.
+   * @param cp
+   * @param filePath
+   * @return
+   */
+  @Nullable
+  private static VirtualFile findFileOnOneClasspath(@NotNull HaxeClasspath cp, @NotNull final String filePath) {
+    final VirtualFileManager vfmInstance = VirtualFileManager.getInstance();
+
+    class MyLambda implements HaxeClasspath.Lambda {
+      public VirtualFile found = null;
+      public boolean processEntry(HaxeClasspathEntry entry) {
+        String dirUrl = entry.getUrl();
+        if (!URLUtil.containsScheme(dirUrl)) {
+          dirUrl = vfmInstance.constructUrl(URLUtil.FILE_PROTOCOL, dirUrl);
+        }
+        VirtualFile dirName = vfmInstance.findFileByUrl(dirUrl);
+        if (null != dirName && dirName.isDirectory()) {
+          found = dirName.findFileByRelativePath(filePath);
+          if (null != found) {
+            return false;  // Stop the search.
+          }
+        }
+        return true;
+      }
+    }
+
+    MyLambda lambda = new MyLambda();
+    cp.iterate(lambda);
+    return lambda.found;
+  }
+
+  /**
+   * Given a module and a list of files, find the first one that occurs on the
+   * classpath.
+   *
+   * @param module - Module from which to obtain the classpath.
+   * @param files - a list of files to check.
+   * @return the first of the list of files that occurs on the classpath, or
+   *         null if none appear there.
+   */
+  @Nullable
+  public static VirtualFile findFirstFileOnClasspath(@NotNull final Module module,
+                                                     @NotNull final java.util.Collection<VirtualFile> files) {
+    if (files.isEmpty()) {
+      return null;
+    }
+
+    final VirtualFileManager vfmInstance = VirtualFileManager.getInstance();
+    final HaxeClasspath cp = ApplicationManager.getApplication().runReadAction(new Computable<HaxeClasspath>() {
+      @Override
+      public HaxeClasspath compute() {
+        return getFullClasspath(module);
+      }
+    });
+
+    class MyLambda implements HaxeClasspath.Lambda {
+      public VirtualFile found;
+      public boolean processEntry(HaxeClasspathEntry entry) {
+        String dirUrl = entry.getUrl();
+        if (!URLUtil.containsScheme(dirUrl)) {
+          dirUrl = vfmInstance.constructUrl(URLUtil.FILE_PROTOCOL, dirUrl);
+        }
+        VirtualFile dirName = vfmInstance.findFileByUrl(dirUrl);
+        if (null != dirName && dirName.isDirectory()) {
+          for (VirtualFile f : files) {
+            if (f.exists()) {
+              // We have a complete path, compare the leading paths.
+              String filePath = f.getCanonicalPath();
+              String dirPath = dirName.getCanonicalPath();
+              if (filePath.startsWith(dirPath)) {
+                found = f;
+              }
+            } else {
+              // We have a partial path, search the path for a matching file.
+              found = dirName.findFileByRelativePath(f.toString());
+            }
+            if (null != found) {
+              return false;
+            }
+          }
+        }
+        return true;
+      }
+    }
+
+    MyLambda lambda = new MyLambda();
+    cp.iterate(lambda);
+    return lambda.found;
+  }
 
 }

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibProjectUpdater.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibProjectUpdater.java
@@ -216,7 +216,10 @@ public class HaxelibProjectUpdater  {
     HaxeClasspath inheritedClasspaths = HaxelibClasspathUtils.getSdkClasspath(
       HaxelibSdkUtils.lookupSdk(module));
     if (rootManager.isSdkInherited()) {
-      inheritedClasspaths.addAll(getProjectClasspath(tracker));
+      // Add project classpaths before SDK class paths for correct precedence.
+      HaxeClasspath projectClasspaths =  getProjectClasspath(tracker);
+      projectClasspaths.addAll(inheritedClasspaths);
+      inheritedClasspaths = projectClasspaths;
     }
 
     class NewPathCollector implements HaxeClasspath.Lambda {

--- a/src/common/com/intellij/plugins/haxe/ide/module/HaxeModuleSettings.java
+++ b/src/common/com/intellij/plugins/haxe/ide/module/HaxeModuleSettings.java
@@ -29,6 +29,7 @@ import com.intellij.plugins.haxe.module.HaxeModuleSettingsBase;
 import com.intellij.plugins.haxe.module.impl.HaxeModuleSettingsBaseImpl;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author: Fedor.Korotkov
@@ -85,6 +86,45 @@ public class HaxeModuleSettings extends HaxeModuleSettingsBaseImpl
   public String getFlexSdkName() {
     return flexSdkName;
   }
+
+  public HaxeTarget getCompilationTarget() {
+    HaxeTarget defaultTarget;
+    String targetArgs;
+
+    if (isUseNmmlToBuild()) {             // NME
+      defaultTarget = getNmeTarget().getOutputTarget();
+      targetArgs = getNmeFlags();
+    } else if (isUseOpenFLToBuild()) {    // OpenFL
+      defaultTarget = getOpenFLTarget().getOutputTarget();
+      targetArgs = getOpenFLFlags();
+    } else {                              // HXML or haxe compiler
+      defaultTarget = getHaxeTarget();
+      targetArgs = getArguments();
+    }
+
+    HaxeTarget t = getTargetFromCompilerArguments(targetArgs);
+    if (null == t) {
+      t = defaultTarget;
+    }
+    return t;
+  }
+
+  @Nullable
+  private static HaxeTarget getTargetFromCompilerArguments(String arguments) {
+    HaxeTarget target = null;
+    if (null != arguments && !arguments.isEmpty()) {
+      String[] args = arguments.split(" ");
+      for (String a : args) {
+        HaxeTarget matched = HaxeTarget.matchOutputTarget(a);
+        if (null != matched) {
+          target = matched;
+          break;
+        }
+      }
+    }
+    return target;
+  }
+
 
   public static HaxeModuleSettings getInstance(@NotNull Module module) {
     return ModuleServiceManager.getService(module, HaxeModuleSettings.class);


### PR DESCRIPTION
Load files using canonical names. (Resolve symlinks so that IDEA does not open
a symlink as a duplicate buffer.)
Use implicit class path entries when searching for relative paths. (haxe/std)