### PR TITLE
issue #388 allow short assign syntax for generics

### DIFF
--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeCompatible.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeCompatible.java
@@ -96,6 +96,10 @@ public class HaxeTypeCompatible {
         }
         return true;
       }
+      // issue #388: allow `public var m:Map<String, String> = new Map();`
+      else if(from.specifics.length == 0) {
+        return true;
+      }
     }
 
     if (to.toStringWithoutConstant().equals(from.toStringWithoutConstant())) {


### PR DESCRIPTION
very long time we had issues with shortcuts for generic instantiation syntax, this syntax is very common and valid:
```
public var triggered(default, null):Signal2<Dispatcher, String> = new Signal2();
public var cache(default, null):Map<String, BaseState> = new Map();
// etc..
```