### PR TITLE
Small various fixes

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -35,6 +35,12 @@
       <p>This build is compatible with @plugin.compatibility.description@</p>
       <p>It was built using IDEA build @idea.sdk.version@</p>
       <p/>
+      <p>0.9.9: (community release)</p>
+      <ul>
+        <li>Fix unhandled exceptions while parsing numeric constants</li>
+        <li>Fix typedef types not resolved variants for completion list</li>
+        <li>Fix error annotation when implements `extern interface`</li>
+      </ul>
       <p>0.9.8: (community release)</p>
       <ul>
         <li>Version 14.1.5 and 14.1.6 compatibility.</li>

--- a/src/common/com/intellij/plugins/haxe/HaxeComponentType.java
+++ b/src/common/com/intellij/plugins/haxe/HaxeComponentType.java
@@ -135,7 +135,8 @@ public enum HaxeComponentType {
     if (element instanceof HaxeEnumDeclaration) {
       return ENUM;
     }
-    if (element instanceof HaxeInterfaceDeclaration) {
+    if (element instanceof HaxeInterfaceDeclaration ||
+        element instanceof HaxeExternInterfaceDeclaration) {
       return INTERFACE;
     }
     if (element instanceof HaxeTypedefDeclaration) {

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeExpressionEvaluator.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeExpressionEvaluator.java
@@ -445,10 +445,10 @@ public class HaxeExpressionEvaluator {
       IElementType type = ((PsiJavaToken)element).getTokenType();
 
       if (type == HaxeTokenTypes.LITINT || type == HaxeTokenTypes.LITHEX || type == HaxeTokenTypes.LITOCT) {
-        return SpecificHaxeClassReference.primitive("Int", element, Integer.decode(element.getText())).createHolder();
+        return SpecificHaxeClassReference.primitive("Int", element, Long.decode(element.getText())).createHolder();
       }
       else if (type == HaxeTokenTypes.LITFLOAT) {
-        return SpecificHaxeClassReference.primitive("Float", element, Float.parseFloat(element.getText())).createHolder();
+        return SpecificHaxeClassReference.primitive("Float", element, Double.parseDouble(element.getText())).createHolder();
       }
       else if (type == HaxeTokenTypes.KFALSE || type == HaxeTokenTypes.KTRUE) {
         return SpecificHaxeClassReference.primitive("Bool", element, type == HaxeTokenTypes.KTRUE).createHolder();

--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -526,8 +526,13 @@ public class HaxeResolveUtil {
       return null;
     }
 
+    // can be accessed without full QName
+    HaxeClass result = findClassByQName(type.getText(), type.getContext());
+    if(result != null) {
+      return result;
+    }
     String name = getQName(type);
-    HaxeClass result = name == null? tryResolveClassByQNameWhenGetQNameFail(type) : findClassByQName(name, type.getContext());
+    result = name == null? tryResolveClassByQNameWhenGetQNameFail(type) : findClassByQName(name, type.getContext());
     result = result != null ? result : tryFindHelper(type);
     result = result != null ? result : findClassByQNameInSuperPackages(type);
     return result;

--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -526,8 +526,8 @@ public class HaxeResolveUtil {
       return null;
     }
 
-    String name = getQName(type);
-    HaxeClass result = name == null? tryResolveClassByQNameWhenGetQNameFail(type) : findClassByQName(name, type.getContext());
+    final String name = getQName(type);
+    HaxeClass result = name == null ? tryResolveClassByQNameWhenGetQNameFail(type) : findClassByQName(name, type.getContext());
     result = result != null ? result : tryFindHelper(type);
     result = result != null ? result : findClassByQNameInSuperPackages(type);
     return result;
@@ -540,18 +540,16 @@ public class HaxeResolveUtil {
       if (topmostParentOfType == null) {
         topmostParentOfType = (HaxeReferenceExpression)type;
       }
+      
+      HaxeClass haxeClass = findClassByQName(topmostParentOfType.getText(), topmostParentOfType.getContext());
+      if (haxeClass != null) {
+        return topmostParentOfType.getText();
+      }
 
-      if (topmostParentOfType != null) {
-        HaxeClass haxeClass = findClassByQName(topmostParentOfType.getText(), topmostParentOfType.getContext());
-        if (haxeClass != null) {
-          return topmostParentOfType.getText();
-        }
-
-        PsiElement parent = type.getParent();
-        HaxeClass classByQName = findClassByQName(parent.getText(), parent.getContext());
-        if (classByQName != null) {
-          return parent.getText();
-        }
+      PsiElement parent = type.getParent();
+      HaxeClass classByQName = findClassByQName(parent.getText(), parent.getContext());
+      if (classByQName != null) {
+        return parent.getText();
       }
     }
 

--- a/testData/annotation.semantic/ImplementExternInterface.hx
+++ b/testData/annotation.semantic/ImplementExternInterface.hx
@@ -1,0 +1,7 @@
+class Test1 implements ExternInterfaceTest {
+  public function fooExtern(b:Int):Int return 2;
+}
+
+extern interface ExternInterfaceTest {
+  function fooExtern(b:Int):Int;
+}

--- a/testData/completion/references/AutodetectProperties.hx
+++ b/testData/completion/references/AutodetectProperties.hx
@@ -3,6 +3,8 @@ class Methods {
   public var test2(default, null):String;
   public var test3(get, never):Float;
   public var test4:Int = 7;
+  public var test5 = 0xFFFFFFFF;
+  public var test6 = 1e300;
 }
 
 class Main {

--- a/testData/completion/references/AutodetectProperties.txt
+++ b/testData/completion/references/AutodetectProperties.txt
@@ -2,3 +2,5 @@ test1:Int
 test2:String
 test3:Float
 test4:Int
+test5:Int
+test6:Float

--- a/testData/completion/references/com/testing/LocalTypedef.hx
+++ b/testData/completion/references/com/testing/LocalTypedef.hx
@@ -1,0 +1,9 @@
+package com.testing;
+
+typedef BarData = com.util.Bar;
+
+class LocalTypedef {
+  private function print(bar:BarData){
+    bar.<caret>
+  }
+}

--- a/testData/completion/references/com/testing/LocalTypedef.txt
+++ b/testData/completion/references/com/testing/LocalTypedef.txt
@@ -1,0 +1,3 @@
+BASIC 2 INCLUDES
+bar
+getName

--- a/testData/completion/references/com/util/Bar.hx
+++ b/testData/completion/references/com/util/Bar.hx
@@ -1,0 +1,7 @@
+package com.util;
+
+class Bar {
+  public var bar:Int;
+  public function new() {}
+  public function getName():String return "Bar";
+}

--- a/testData/goto/TypeDef5.hx
+++ b/testData/goto/TypeDef5.hx
@@ -1,0 +1,8 @@
+typedef Foo = com.bar.Foo;
+
+class TypeDef5 {
+  function main(){
+    var foo:Foo;
+    fo<caret>o;
+  }
+}

--- a/testSrc/com/intellij/plugins/haxe/actions/HaxeGoToDeclarationActionTest.java
+++ b/testSrc/com/intellij/plugins/haxe/actions/HaxeGoToDeclarationActionTest.java
@@ -269,6 +269,10 @@ public class HaxeGoToDeclarationActionTest extends HaxeCodeInsightFixtureTestCas
     doTest(myFixture.configureByFiles("TypeDef4.hx"), 1);
   }
 
+  public void testTypeDef5() {
+    doTest(myFixture.configureByFiles("TypeDef5.hx", "com/bar/Foo.hx"), 1);
+  }
+
   public void testArrayAccess1() {
     doTest(myFixture.configureByFiles("ArrayAccess1.hx", "std/String.hx", "std/Array.hx", "std/StdTypes.hx"), 1);
   }

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -175,6 +175,10 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
     doTestNoFixWithWarnings();
   }
 
+  public void testImplementExternInterface() throws Exception {
+    doTestNoFixWithWarnings();
+  }
+
   public void testSimpleAssignUnknownGeneric() throws Exception {
     doTestNoFixWithWarnings();
   }

--- a/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
+++ b/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
@@ -192,6 +192,11 @@ public class ReferenceCompletionTest extends HaxeCompletionTestBase {
     doTestInclude();
   }
 
+  public void testLocalTypedef() throws Throwable {
+    myFixture.configureByFiles("com/testing/LocalTypedef.hx", "com/util/Bar.hx");
+    doTestVariantsInner("com/testing/LocalTypedef.txt");
+  }
+
   // @TODO: Temporarily disabled. Not being recognized for an unknown reason.
   /*
   public void testExtensionMethod1() throws Throwable {


### PR DESCRIPTION
1. Tiny HaxeComponentType fix: extending from `extern interface`
2. Remove unhandled exceptions in HaxeExpressionEvaluator: increase resolutions for constants parsing
3. HaxeResolveUtil fix: variants completions for local declarated types