### PR TITLE
Fixing regexp to match errors on windows platform.

### DIFF
--- a/common/src/com/intellij/plugins/haxe/compilation/HaxeCompilerError.java
+++ b/common/src/com/intellij/plugins/haxe/compilation/HaxeCompilerError.java
@@ -199,14 +199,14 @@ public class HaxeCompilerError {
         ("Error: Library ([\\S]+) is not installed(.*)");
     static Pattern pBareError = Pattern.compile("([^:]*)Error:(.*)", Pattern.CASE_INSENSITIVE);
     static Pattern pColumnError =
-        Pattern.compile("([^:]+):([\\d]+): characters ([\\d]+)-[\\d]+ :(.*)");
+        Pattern.compile("(.+?):([\\d]+): characters ([\\d]+)-[\\d]+ :(.*)");
     static Pattern pLineError =
-        Pattern.compile("([^:]+):([\\d]+): lines [\\d]+-[\\d]+ :(.*)");
+        Pattern.compile("(.+?):([\\d]+): lines [\\d]+-[\\d]+ :(.*)");
 
     // Unfortunately, the Haxe compiler doesn't always mark its error lines with
     // a useful "Warning" or "Error" prefix.  However, the common error output (main.ml)
     // uses the pattern "%s : %s".
-    static Pattern pGenericError = Pattern.compile("([^:]+) : (.+)");
+    static Pattern pGenericError = Pattern.compile("(.+?) : (.+)");
 
     // These are a few well-known informational patterns that should NOT be marked
     // as errors.  Keeping this up to date will always be an arms race.


### PR DESCRIPTION
There was an error to match error messages on Windows platform, because for example with this error message the math will fail:
C:/repos/HlsPlayerModule.hx:87: characters 64-65 : Missing ;

Why?
Because it starts with C: and the first : is used. On linux there is no problem with this, because your root looks like /, not C:/ 

Instead of the previous pattern I updated to match anything event :, but not greedy, so this way it will match other crazy things also that could appear in file path.