### PR TITLE
Make code generation deterministic

### DIFF
--- a/src/common/com/intellij/plugins/haxe/util/HaxeElementGenerator.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeElementGenerator.java
@@ -30,6 +30,8 @@ import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.testFramework.LightVirtualFile;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -73,11 +75,25 @@ public class HaxeElementGenerator {
     return (HaxeVarDeclaration)haxeClass.getVarDeclarations().iterator().next();
   }
 
+  // XXX: Eventually, this ordering should come from the class order in
+  //      preferences... once we have one.
+  private static List<HaxeNamedComponent> sortNamedSubComponents(List<HaxeNamedComponent> unsorted) {
+    Collections.sort(unsorted, new Comparator<HaxeNamedComponent>() {
+      @Override
+      public int compare(HaxeNamedComponent o1, HaxeNamedComponent o2) {
+        String name1 = o1.getName();
+        String name2 = o2.getName();
+        return name1.compareTo(name2);
+      }
+    });
+    return unsorted;
+  }
+
   public static List<HaxeNamedComponent> createNamedSubComponentsFromText(Project myProject, String text) {
     final PsiFile dummyFile = createDummyFile(myProject, HaxeCodeGenerateUtil.wrapFunction(text).getFirst());
     final HaxeClass haxeClass = PsiTreeUtil.getChildOfType(dummyFile, HaxeClass.class);
     assert haxeClass != null;
-    return HaxeResolveUtil.findNamedSubComponents(haxeClass);
+    return sortNamedSubComponents(HaxeResolveUtil.findNamedSubComponents(haxeClass));
   }
 
   @Nullable

--- a/src/common/com/intellij/plugins/haxe/util/HaxeElementGenerator.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeElementGenerator.java
@@ -30,6 +30,7 @@ import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.testFramework.LightVirtualFile;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -78,7 +79,9 @@ public class HaxeElementGenerator {
   // XXX: Eventually, this ordering should come from the class order in
   //      preferences... once we have one.
   private static List<HaxeNamedComponent> sortNamedSubComponents(List<HaxeNamedComponent> unsorted) {
-    Collections.sort(unsorted, new Comparator<HaxeNamedComponent>() {
+    // Can't sort a hashed collection, so we must copy it to an orderable type.
+    List<HaxeNamedComponent> sorted = new ArrayList<HaxeNamedComponent>(unsorted);
+    Collections.sort(sorted, new Comparator<HaxeNamedComponent>() {
       @Override
       public int compare(HaxeNamedComponent o1, HaxeNamedComponent o2) {
         String name1 = o1.getName();
@@ -86,7 +89,7 @@ public class HaxeElementGenerator {
         return name1.compareTo(name2);
       }
     });
-    return unsorted;
+    return sorted;
   }
 
   public static List<HaxeNamedComponent> createNamedSubComponentsFromText(Project myProject, String text) {

--- a/testData/generate/GetterSetter1.txt
+++ b/testData/generate/GetterSetter1.txt
@@ -2,12 +2,12 @@ class GetterSetter1 {
     @:isVar public var foo(get, set):Int;
     @:isVar public var bar(get, set):String;
 
-    function set_foo(value:Int) {
-        return this.foo = value;
-    }
-
     function get_foo():Int {
         return foo;
+    }
+
+    function set_foo(value:Int) {
+        return this.foo = value;
     }
 
     function get_bar():String {


### PR DESCRIPTION
This fixes the issue between Java 1.6 and 1.8 when running the testGetterSetter1() method. The crux of the problem was a different hashing algorithm that changed the order of the elements in the hash table. Now, we sort the functions after we generate them.