### PR TITLE
Bugfix/package resolving

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -35,6 +35,7 @@
       <p>This build is compatible with @plugin.compatibility.description@</p>
       <p>It was built using IDEA build @idea.sdk.version@</p>
       <p/>
+      <li>Better packages resolving</li>
       <p>0.9.9: (community release)</p>
       <ul>
         <li>IDEA v15 compatibility.  (IDEA 13 compatiblity removed.)</li>

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -620,8 +620,9 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
         }
       }
     }
-    if (leftReference != null && getParent() instanceof HaxeReference && name != null && leftReference.getText().equals(
-      name)) {
+    if (leftReference != null && getParent() instanceof HaxeReference && name != null &&
+        HaxeResolveUtil.splitQName(leftReference.getText()).getSecond().equals(name)) {
+
       addClassStaticMembersVariants(suggestedVariants, result.getHaxeClass(),
                                     !(leftReference instanceof HaxeThisExpression));
       addChildClassVariants(suggestedVariants, result.getHaxeClass());
@@ -635,7 +636,6 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
                                          !(leftReference instanceof HaxeThisExpression));
         addUsingVariants(suggestedVariants, suggestedVariantsExtensions, haxeClass,
                          HaxeResolveUtil.findUsingClasses(getContainingFile()));
-        addChildClassVariants(suggestedVariants, haxeClass);
       }
     }
     else {
@@ -656,6 +656,9 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
 
     if (leftTarget instanceof PsiPackage) {
       return ArrayUtil.mergeArrays(variants, ((PsiPackage)leftTarget).getSubPackages());
+    }
+    else if (leftTarget instanceof HaxeFile) {
+      return ArrayUtil.mergeArrays(variants, ((HaxeFile)leftTarget).getClasses());
     }
     else if (leftReference == null) {
       PsiPackage rootPackage = JavaPsiFacade.getInstance(getElement().getProject()).findPackage("");


### PR DESCRIPTION
Correct package resolving.
- Fix completion a little
- Fix some refactoring issues
- All tests passed

Test cases:
- hold cmd/ctrl button and hover the cursor on identifiers of package - works now like in Java
- better goto (now parts of packages resolves as path to package with left-references)
- try to rename package (because the resolving of package is fixed - more identifiers renames correctly)
- try to type packages inside the class body (variable/package problem is not reproduced, completion works better because of no conflict across for example `intellij.haxe` and `haxe.macro`)

Just a couple of examples to show what was fixed:

Previous (0.9.9):
![image](https://cloud.githubusercontent.com/assets/3038174/13032380/5689416e-d301-11e5-841e-f9e31466c7d6.png)
![image](https://cloud.githubusercontent.com/assets/3038174/13032383/7f8cb85c-d301-11e5-8996-f036b324bf81.png)
![image](https://cloud.githubusercontent.com/assets/3038174/13032394/aa4ad0ec-d301-11e5-9572-fabe64f869c9.png)

New (PR):
![image](https://cloud.githubusercontent.com/assets/3038174/13032349/1831e890-d300-11e5-8b95-32814e1bd27d.png)
![image](https://cloud.githubusercontent.com/assets/3038174/13032351/30acd358-d300-11e5-8ab2-6399581c23bb.png)
