### PR TITLE
Abstract Enums support

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -39,6 +39,7 @@
       <ul>
         <li>Better packages resolving</li>
         <li>Fix catch parameter declaration (issue #419)</li>
+        <li>General "@:enum abstract" support (issues #427, #428, #429)</li>
       </ul>
       <p>0.9.9: (community release)</p>
       <ul>

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
@@ -33,6 +33,7 @@ import com.intellij.plugins.haxe.model.fixer.HaxeModifierReplaceVisibilityFixer;
 import com.intellij.plugins.haxe.model.type.HaxeTypeCompatible;
 import com.intellij.plugins.haxe.model.type.HaxeTypeResolver;
 import com.intellij.plugins.haxe.model.type.ResultHolder;
+import com.intellij.plugins.haxe.util.HaxeAbstractEnumUtil;
 import com.intellij.plugins.haxe.util.HaxeResolveUtil;
 import com.intellij.plugins.haxe.util.PsiFileUtils;
 import com.intellij.psi.*;
@@ -76,7 +77,14 @@ class TypeTagChecker {
     final AnnotationHolder holder
   ) {
     final ResultHolder type1 = HaxeTypeResolver.getTypeFromTypeTag(tag, erroredElement);
-    final ResultHolder type2 = HaxeTypeResolver.getPsiElementType(initExpression);
+    ResultHolder t2 = HaxeTypeResolver.getPsiElementType(initExpression);
+
+    ResultHolder aeExpr = HaxeAbstractEnumUtil.getStaticMemberExpression(initExpression.getExpression());
+    if(aeExpr != null) {
+      t2 = aeExpr;
+    }
+    final ResultHolder type2 = t2;
+
     final HaxeDocumentModel document = HaxeDocumentModel.fromElement(tag);
     if (!type1.canAssign(type2)) {
       // @TODO: Move to bundle
@@ -96,8 +104,10 @@ class TypeTagChecker {
       });
     }
     else if (requireConstant && type2.getType().getConstant() == null) {
+      //if(!HaxeAbstractEnumUtil.checkExpressionIsConst(initExpression.getExpression())) {
       // @TODO: Move to bundle
       holder.createErrorAnnotation(erroredElement, "Parameter default type should be constant but was " + type2);
+      //}
     }
   }
 }

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
@@ -77,13 +77,7 @@ class TypeTagChecker {
     final AnnotationHolder holder
   ) {
     final ResultHolder type1 = HaxeTypeResolver.getTypeFromTypeTag(tag, erroredElement);
-    ResultHolder t2 = HaxeTypeResolver.getPsiElementType(initExpression);
-
-    ResultHolder aeExpr = HaxeAbstractEnumUtil.getStaticMemberExpression(initExpression.getExpression());
-    if(aeExpr != null) {
-      t2 = aeExpr;
-    }
-    final ResultHolder type2 = t2;
+    final ResultHolder type2 = getTypeFromVarInit(initExpression);
 
     final HaxeDocumentModel document = HaxeDocumentModel.fromElement(tag);
     if (!type1.canAssign(type2)) {
@@ -104,11 +98,19 @@ class TypeTagChecker {
       });
     }
     else if (requireConstant && type2.getType().getConstant() == null) {
-      //if(!HaxeAbstractEnumUtil.checkExpressionIsConst(initExpression.getExpression())) {
-      // @TODO: Move to bundle
+      // TODO: Move to bundle
       holder.createErrorAnnotation(erroredElement, "Parameter default type should be constant but was " + type2);
-      //}
     }
+  }
+
+  @NotNull
+  static ResultHolder getTypeFromVarInit(HaxeVarInit init) {
+    final ResultHolder abstractEnumFieldInitType = HaxeAbstractEnumUtil.getStaticMemberExpression(init.getExpression());
+    if(abstractEnumFieldInitType != null) {
+      return abstractEnumFieldInitType;
+    }
+    // fallback to simple init expression
+    return HaxeTypeResolver.getPsiElementType(init);
   }
 }
 

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -740,11 +740,18 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
 
     boolean extern = haxeClass.isExtern();
     boolean isEnum = haxeClass instanceof HaxeEnumDeclaration;
+    boolean isAbstractEnum = HaxeAbstractEnumUtil.isAbstractEnum(haxeClass);
 
     for (HaxeNamedComponent namedComponent : HaxeResolveUtil.findNamedSubComponents(haxeClass)) {
       final boolean needFilter = filterByAccess && !namedComponent.isPublic();
-      if ((extern || !needFilter) && (namedComponent.isStatic() || isEnum) && namedComponent.getComponentName() != null) {
-        suggestedVariants.add(namedComponent.getComponentName());
+      final HaxeComponentName componentName = namedComponent.getComponentName();
+      if(componentName != null) {
+        if(isAbstractEnum && HaxeAbstractEnumUtil.isAbstractEnumField(namedComponent)) {
+          suggestedVariants.add(componentName);
+        }
+        else if ((extern || !needFilter) && (namedComponent.isStatic() || isEnum)) {
+          suggestedVariants.add(componentName);
+        }
       }
     }
   }
@@ -755,9 +762,13 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
     }
 
     boolean extern = haxeClass.isExtern();
+    boolean isAbstractEnum = HaxeAbstractEnumUtil.isAbstractEnum(haxeClass);
 
     for (HaxeNamedComponent namedComponent : HaxeResolveUtil.findNamedSubComponents(haxeClass)) {
       final boolean needFilter = filterByAccess && !namedComponent.isPublic();
+      if(isAbstractEnum && HaxeAbstractEnumUtil.isAbstractEnumField(namedComponent)) {
+        continue;
+      }
       if ((extern || !needFilter) && !namedComponent.isStatic() && namedComponent.getComponentName() != null) {
         suggestedVariants.add(namedComponent.getComponentName());
       }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -746,7 +746,7 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
       final boolean needFilter = filterByAccess && !namedComponent.isPublic();
       final HaxeComponentName componentName = namedComponent.getComponentName();
       if(componentName != null) {
-        if(isAbstractEnum && HaxeAbstractEnumUtil.isAbstractEnumField(namedComponent)) {
+        if(isAbstractEnum && HaxeAbstractEnumUtil.checkField(namedComponent)) {
           suggestedVariants.add(componentName);
         }
         else if ((extern || !needFilter) && (namedComponent.isStatic() || isEnum)) {
@@ -766,7 +766,7 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
 
     for (HaxeNamedComponent namedComponent : HaxeResolveUtil.findNamedSubComponents(haxeClass)) {
       final boolean needFilter = filterByAccess && !namedComponent.isPublic();
-      if(isAbstractEnum && HaxeAbstractEnumUtil.isAbstractEnumField(namedComponent)) {
+      if(isAbstractEnum && HaxeAbstractEnumUtil.checkField(namedComponent)) {
         continue;
       }
       if ((extern || !needFilter) && !namedComponent.isStatic() && namedComponent.getComponentName() != null) {

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -19,7 +19,6 @@ package com.intellij.plugins.haxe.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.io.FileUtil;
@@ -28,7 +27,6 @@ import com.intellij.plugins.haxe.ide.HaxeLookupElement;
 import com.intellij.plugins.haxe.ide.refactoring.move.HaxeFileMoveHandler;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.*;
-import com.intellij.plugins.haxe.model.type.HaxeTypeResolver;
 import com.intellij.plugins.haxe.util.*;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.source.resolve.ResolveCache;
@@ -42,7 +40,6 @@ import com.intellij.util.ArrayUtil;
 import com.intellij.util.IncorrectOperationException;
 import com.intellij.util.containers.ContainerUtil;
 import gnu.trove.THashSet;
-import org.apache.log4j.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -746,7 +743,7 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
       final boolean needFilter = filterByAccess && !namedComponent.isPublic();
       final HaxeComponentName componentName = namedComponent.getComponentName();
       if(componentName != null) {
-        if(isAbstractEnum && HaxeAbstractEnumUtil.checkField(namedComponent)) {
+        if(isAbstractEnum && HaxeAbstractEnumUtil.couldBeAbstractEnumField(namedComponent)) {
           suggestedVariants.add(componentName);
         }
         else if ((extern || !needFilter) && (namedComponent.isStatic() || isEnum)) {
@@ -766,7 +763,7 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
 
     for (HaxeNamedComponent namedComponent : HaxeResolveUtil.findNamedSubComponents(haxeClass)) {
       final boolean needFilter = filterByAccess && !namedComponent.isPublic();
-      if(isAbstractEnum && HaxeAbstractEnumUtil.checkField(namedComponent)) {
+      if(isAbstractEnum && HaxeAbstractEnumUtil.couldBeAbstractEnumField(namedComponent)) {
         continue;
       }
       if ((extern || !needFilter) && !namedComponent.isStatic() && namedComponent.getComponentName() != null) {

--- a/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
@@ -102,9 +102,17 @@ public class HaxeClassModel {
   public HaxeTypeOrAnonymous getAbstractUnderlyingType() {
     if (!isAbstract()) return null;
     PsiElement[] children = getPsi().getChildren();
-    if (children.length >= 2) {
-      if (children[1] instanceof HaxeTypeOrAnonymous) {
-        return (HaxeTypeOrAnonymous)children[1];
+    // FIX: support list of metas before ComponentName
+    for(int i = 0; i < children.length; ++i) {
+      PsiElement child = children[i];
+      if(child instanceof HaxeComponentName) {
+        if(i + 1 < children.length) {
+          child = children[i + 1];
+          if(child instanceof HaxeTypeOrAnonymous) {
+            return (HaxeTypeOrAnonymous)child;
+          }
+        }
+        break;
       }
     }
     return null;

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeClassReference.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeClassReference.java
@@ -37,7 +37,7 @@ public class HaxeClassReference {
   public HaxeClassReference(HaxeClassModel clazz, @NotNull PsiElement elementContext) {
     this.name = clazz.getName();
     this.elementContext = elementContext;
-    this.clazz = null;
+    this.clazz = clazz;
   }
 
   public HaxeClass getHaxeClass() {

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeResolver.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeResolver.java
@@ -81,30 +81,35 @@ public class HaxeTypeResolver {
   static private ResultHolder getFieldType(AbstractHaxeNamedComponent comp) {
     //ResultHolder type = getTypeFromTypeTag(comp);
     // Here detect assignment
-
-    ResultHolder result = HaxeAbstractEnumUtil.getFieldType(comp);
-    if(result != null) {
-      return result;
+    final ResultHolder abstractEnumType = HaxeAbstractEnumUtil.getFieldType(comp);
+    if(abstractEnumType != null) {
+      return abstractEnumType;
     }
 
     if (comp instanceof HaxeVarDeclarationPart) {
-      HaxeTypeTag typeTag = ((HaxeVarDeclarationPart)comp).getTypeTag();
-      if (typeTag != null) {
-        return getTypeFromTypeTag(typeTag, comp);
-      }
+      ResultHolder result = null;
 
       HaxeVarInit init = ((HaxeVarDeclarationPart)comp).getVarInit();
       if (init != null) {
         PsiElement child = init.getExpression();
-        ResultHolder type1 = HaxeTypeResolver.getPsiElementType(child);
+        final ResultHolder initType = HaxeTypeResolver.getPsiElementType(child);
         HaxeVarDeclaration decl = ((HaxeVarDeclaration)comp.getParent());
         boolean isConstant = false;
         if (decl != null) {
-          isConstant = decl.hasModifierProperty(HaxePsiModifier.INLINE);
-          PsiModifierList modifierList = decl.getModifierList();
-          //System.out.println(decl.getText());
+          isConstant = decl.hasModifierProperty(HaxePsiModifier.INLINE) && decl.isStatic();
         }
-        return isConstant ? type1 : type1.withConstantValue(null);
+        result = isConstant ? initType : initType.withConstantValue(null);
+      }
+
+      HaxeTypeTag typeTag = ((HaxeVarDeclarationPart)comp).getTypeTag();
+      if (typeTag != null) {
+        final ResultHolder typeFromTag = getTypeFromTypeTag(typeTag, comp);
+        final Object initConstant = result != null ? result.getType().getConstant() : null;
+        result = typeFromTag.withConstantValue(initConstant);
+      }
+
+      if(result != null) {
+        return result;
       }
     }
 

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeResolver.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeResolver.java
@@ -21,6 +21,7 @@ import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxeNamedComponent;
 import com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodImpl;
+import com.intellij.plugins.haxe.util.HaxeAbstractEnumUtil;
 import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -80,8 +81,18 @@ public class HaxeTypeResolver {
   static private ResultHolder getFieldType(AbstractHaxeNamedComponent comp) {
     //ResultHolder type = getTypeFromTypeTag(comp);
     // Here detect assignment
+
+    ResultHolder result = HaxeAbstractEnumUtil.getFieldType(comp);
+    if(result != null) {
+      return result;
+    }
+
     if (comp instanceof HaxeVarDeclarationPart) {
       HaxeTypeTag typeTag = ((HaxeVarDeclarationPart)comp).getTypeTag();
+      if (typeTag != null) {
+        return getTypeFromTypeTag(typeTag, comp);
+      }
+
       HaxeVarInit init = ((HaxeVarDeclarationPart)comp).getVarInit();
       if (init != null) {
         PsiElement child = init.getExpression();
@@ -94,9 +105,6 @@ public class HaxeTypeResolver {
           //System.out.println(decl.getText());
         }
         return isConstant ? type1 : type1.withConstantValue(null);
-      }
-      if (typeTag != null) {
-        return getTypeFromTypeTag(typeTag, comp);
       }
     }
 

--- a/src/common/com/intellij/plugins/haxe/util/HaxeAbstractEnumUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeAbstractEnumUtil.java
@@ -32,11 +32,11 @@ public class HaxeAbstractEnumUtil {
 
   public static boolean isAbstractEnum(@Nullable PsiClass clazz) {
     if(clazz != null && clazz instanceof HaxeAbstractClassDeclaration) {
-      final HaxeMacroClassList macroListDecl = ((HaxeAbstractClassDeclaration)clazz).getMacroClassList();
-      final List<HaxeMacroClass> macroList = macroListDecl != null ? macroListDecl.getMacroClassList() : null;
-      if(macroList != null) {
-        for (HaxeMacroClass macroClass : macroList) {
-          if (macroClass.getText().equals("@:enum")) {
+      final HaxeMacroClassList metaList = ((HaxeAbstractClassDeclaration)clazz).getMacroClassList();
+      final List<HaxeMacroClass> metas = metaList != null ? metaList.getMacroClassList() : null;
+      if(metas != null) {
+        for (HaxeMacroClass meta : metas) {
+          if (meta.getText().equals("@:enum")) {
             return true;
           }
         }
@@ -57,32 +57,6 @@ public class HaxeAbstractEnumUtil {
     return false;
   }
 
-  //public static boolean checkFieldType(@Nullable PsiElement element) {
-  //  if(element != null && element instanceof HaxeVarDeclarationPart) {
-  //    final HaxeVarDeclarationPart decl = (HaxeVarDeclarationPart)element;
-  //    final HaxeTypeTag tag = decl.getTypeTag();
-  //    if (tag == null) {
-  //      return true;
-  //    }
-  //    final String className = decl.getContainingClass().getNameIdentifier().getText();
-  //    return className.equals(tag.getText());
-  //    //if(containingClass instanceof HaxeAbstractClassDeclaration)
-  //    //final SpecificHaxeClassReference classRef = HaxeTypeResolver.getTypeFromTypeTag(tag, element).getClassType();
-  //    //return classRef != null && classRef.getHaxeClass() == containingClass;
-  //  }
-  //  return false;
-  //}
-
-  @Nullable
-  public static HaxeAbstractClassDeclaration getFieldClass(@Nullable PsiElement element) {
-    if (!HaxeAbstractEnumUtil.isAbstractEnumField(element)) {
-      return null;
-    }
-    final HaxeAbstractClassDeclaration abstractEnumClass =
-      PsiTreeUtil.getParentOfType(element, HaxeAbstractClassDeclaration.class);
-    return isAbstractEnum(abstractEnumClass) ? abstractEnumClass : null;
-  }
-
   @Nullable
   public static HaxeClassResolveResult resolveFieldType(@Nullable PsiElement element) {
     final HaxeClass cls = getFieldClass(element);
@@ -99,20 +73,6 @@ public class HaxeAbstractEnumUtil {
         .withConstantValue(element.getText());
   }
 
-  //public static boolean checkExpressionIsConst(@Nullable PsiElement expression) {
-  //  if(expression != null) {
-  //    final HaxeReference[] childReferences = PsiTreeUtil.getChildrenOfType(expression, HaxeReference.class);
-  //    if (childReferences != null && childReferences.length == 2) {
-  //      final HaxeClass leftClass = childReferences[0].resolveHaxeClass().getHaxeClass();
-  //      if (isAbstractEnum(leftClass)) {
-  //        final HaxeNamedComponent field = leftClass.findHaxeFieldByName(childReferences[1].getText());
-  //        return HaxeAbstractEnumUtil.isAbstractEnumField(field);
-  //      }
-  //    }
-  //  }
-  //  return false;
-  //}
-
   @Nullable
   public static ResultHolder getStaticMemberExpression(@Nullable PsiElement expression) {
     if(expression != null) {
@@ -121,6 +81,24 @@ public class HaxeAbstractEnumUtil {
         final HaxeClass leftClass = childReferences[0].resolveHaxeClass().getHaxeClass();
         if (isAbstractEnum(leftClass)) {
           return getFieldType(leftClass.findHaxeFieldByName(childReferences[1].getText()));
+        }
+      }
+    }
+    return null;
+  }
+
+  /*** HELPERS ***/
+
+  @Nullable
+  private static HaxeAbstractClassDeclaration getFieldClass(@Nullable PsiElement element) {
+    final HaxeVarDeclarationPart varDecl = element != null && (element instanceof HaxeVarDeclarationPart) ?
+                                           (HaxeVarDeclarationPart)element : null;
+    if (varDecl != null && HaxeAbstractEnumUtil.isAbstractEnumField(varDecl)) {
+      final HaxeAbstractClassDeclaration abstractEnumClass =
+        PsiTreeUtil.getParentOfType(varDecl, HaxeAbstractClassDeclaration.class);
+      if (isAbstractEnum(abstractEnumClass)) {
+        if (varDecl.getTypeTag() == null) {
+          return abstractEnumClass;
         }
       }
     }

--- a/src/common/com/intellij/plugins/haxe/util/HaxeAbstractEnumUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeAbstractEnumUtil.java
@@ -29,6 +29,9 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
+/**
+ * Extensions for resolving and analyzing Haxe @:enum abstract type
+ */
 public class HaxeAbstractEnumUtil {
 
   @Contract("null -> false")
@@ -52,7 +55,7 @@ public class HaxeAbstractEnumUtil {
    * IMPORTANT: This method doesn't check if this field inside `@:enum abstract`!
    */
   @Contract("null -> false")
-  public static boolean checkField(@Nullable PsiElement element) {
+  public static boolean couldBeAbstractEnumField(@Nullable PsiElement element) {
     if(element != null && element instanceof HaxeVarDeclarationPart) {
       final HaxeVarDeclarationPart decl = (HaxeVarDeclarationPart)element;
        if(decl.getPropertyDeclaration() == null && !decl.isStatic()) {
@@ -111,7 +114,7 @@ public class HaxeAbstractEnumUtil {
   private static HaxeClass getFieldClass(@Nullable PsiElement element) {
     final HaxeVarDeclarationPart varDecl = element != null && (element instanceof HaxeVarDeclarationPart) ?
                                            (HaxeVarDeclarationPart)element : null;
-    if (checkField(varDecl)) {
+    if (couldBeAbstractEnumField(varDecl)) {
       final HaxeAbstractClassDeclaration abstractEnumClass =
         PsiTreeUtil.getParentOfType(varDecl, HaxeAbstractClassDeclaration.class);
       if (isAbstractEnum(abstractEnumClass)) {

--- a/src/common/com/intellij/plugins/haxe/util/HaxeAbstractEnumUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeAbstractEnumUtil.java
@@ -24,12 +24,14 @@ import com.intellij.plugins.haxe.model.type.SpecificHaxeClassReference;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public class HaxeAbstractEnumUtil {
 
+  @Contract("null -> false")
   public static boolean isAbstractEnum(@Nullable PsiClass clazz) {
     if(clazz != null && clazz instanceof HaxeAbstractClassDeclaration) {
       final HaxeMacroClassList metaList = ((HaxeAbstractClassDeclaration)clazz).getMacroClassList();
@@ -45,12 +47,15 @@ public class HaxeAbstractEnumUtil {
     return false;
   }
 
-  public static boolean isAbstractEnumField(@Nullable PsiElement element) {
+  /**
+   * If this element suitable for processing by `@:enum abstract` logic
+   * IMPORTANT: This method doesn't check if this field inside `@:enum abstract`!
+   */
+  @Contract("null -> false")
+  public static boolean checkField(@Nullable PsiElement element) {
     if(element != null && element instanceof HaxeVarDeclarationPart) {
       final HaxeVarDeclarationPart decl = (HaxeVarDeclarationPart)element;
-      final PsiClass containingClass = decl.getContainingClass();
-      if(containingClass instanceof HaxeAbstractClassDeclaration &&
-         decl.getPropertyDeclaration() == null && !decl.isStatic()) {
+       if(decl.getPropertyDeclaration() == null && !decl.isStatic()) {
         return true;
       }
     }
@@ -80,6 +85,7 @@ public class HaxeAbstractEnumUtil {
   }
 
   @Nullable
+  @Contract("null -> null")
   public static ResultHolder getStaticMemberExpression(@Nullable PsiElement expression) {
     if(expression != null) {
       final HaxeReference[] childReferences = PsiTreeUtil.getChildrenOfType(expression, HaxeReference.class);
@@ -105,7 +111,7 @@ public class HaxeAbstractEnumUtil {
   private static HaxeClass getFieldClass(@Nullable PsiElement element) {
     final HaxeVarDeclarationPart varDecl = element != null && (element instanceof HaxeVarDeclarationPart) ?
                                            (HaxeVarDeclarationPart)element : null;
-    if (varDecl != null && isAbstractEnumField(varDecl)) {
+    if (checkField(varDecl)) {
       final HaxeAbstractClassDeclaration abstractEnumClass =
         PsiTreeUtil.getParentOfType(varDecl, HaxeAbstractClassDeclaration.class);
       if (isAbstractEnum(abstractEnumClass)) {

--- a/src/common/com/intellij/plugins/haxe/util/HaxeAbstractEnumUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeAbstractEnumUtil.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2016 AS3Boyan
+ * Copyright 2014-2014 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.util;
+
+import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.model.type.HaxeClassReference;
+import com.intellij.plugins.haxe.model.type.ResultHolder;
+import com.intellij.plugins.haxe.model.type.SpecificHaxeClassReference;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class HaxeAbstractEnumUtil {
+
+  public static boolean isAbstractEnum(@Nullable PsiClass clazz) {
+    if(clazz != null && clazz instanceof HaxeAbstractClassDeclaration) {
+      final HaxeMacroClassList macroListDecl = ((HaxeAbstractClassDeclaration)clazz).getMacroClassList();
+      final List<HaxeMacroClass> macroList = macroListDecl != null ? macroListDecl.getMacroClassList() : null;
+      if(macroList != null) {
+        for (HaxeMacroClass macroClass : macroList) {
+          if (macroClass.getText().equals("@:enum")) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  public static boolean isAbstractEnumField(@Nullable PsiElement element) {
+    if(element != null && element instanceof HaxeVarDeclarationPart) {
+      final HaxeVarDeclarationPart decl = (HaxeVarDeclarationPart)element;
+      final PsiClass containingClass = decl.getContainingClass();
+      if(containingClass instanceof HaxeAbstractClassDeclaration &&
+         decl.getPropertyDeclaration() == null && !decl.isStatic()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  //public static boolean checkFieldType(@Nullable PsiElement element) {
+  //  if(element != null && element instanceof HaxeVarDeclarationPart) {
+  //    final HaxeVarDeclarationPart decl = (HaxeVarDeclarationPart)element;
+  //    final HaxeTypeTag tag = decl.getTypeTag();
+  //    if (tag == null) {
+  //      return true;
+  //    }
+  //    final String className = decl.getContainingClass().getNameIdentifier().getText();
+  //    return className.equals(tag.getText());
+  //    //if(containingClass instanceof HaxeAbstractClassDeclaration)
+  //    //final SpecificHaxeClassReference classRef = HaxeTypeResolver.getTypeFromTypeTag(tag, element).getClassType();
+  //    //return classRef != null && classRef.getHaxeClass() == containingClass;
+  //  }
+  //  return false;
+  //}
+
+  @Nullable
+  public static HaxeAbstractClassDeclaration getFieldClass(@Nullable PsiElement element) {
+    if (!HaxeAbstractEnumUtil.isAbstractEnumField(element)) {
+      return null;
+    }
+    final HaxeAbstractClassDeclaration abstractEnumClass =
+      PsiTreeUtil.getParentOfType(element, HaxeAbstractClassDeclaration.class);
+    return isAbstractEnum(abstractEnumClass) ? abstractEnumClass : null;
+  }
+
+  @Nullable
+  public static HaxeClassResolveResult resolveFieldType(@Nullable PsiElement element) {
+    final HaxeClass cls = getFieldClass(element);
+    return cls != null ? HaxeClassResolveResult.create(cls) : null;
+  }
+
+  @Nullable
+  public static ResultHolder getFieldType(@Nullable PsiElement element) {
+    final HaxeClass cls = getFieldClass(element);
+    if(cls == null || element == null) {
+      return null;
+    }
+    return new ResultHolder(SpecificHaxeClassReference.withoutGenerics(new HaxeClassReference(cls.getModel(), element)))
+        .withConstantValue(element.getText());
+  }
+
+  //public static boolean checkExpressionIsConst(@Nullable PsiElement expression) {
+  //  if(expression != null) {
+  //    final HaxeReference[] childReferences = PsiTreeUtil.getChildrenOfType(expression, HaxeReference.class);
+  //    if (childReferences != null && childReferences.length == 2) {
+  //      final HaxeClass leftClass = childReferences[0].resolveHaxeClass().getHaxeClass();
+  //      if (isAbstractEnum(leftClass)) {
+  //        final HaxeNamedComponent field = leftClass.findHaxeFieldByName(childReferences[1].getText());
+  //        return HaxeAbstractEnumUtil.isAbstractEnumField(field);
+  //      }
+  //    }
+  //  }
+  //  return false;
+  //}
+
+  @Nullable
+  public static ResultHolder getStaticMemberExpression(@Nullable PsiElement expression) {
+    if(expression != null) {
+      final HaxeReference[] childReferences = PsiTreeUtil.getChildrenOfType(expression, HaxeReference.class);
+      if (childReferences != null && childReferences.length == 2) {
+        final HaxeClass leftClass = childReferences[0].resolveHaxeClass().getHaxeClass();
+        if (isAbstractEnum(leftClass)) {
+          return getFieldType(leftClass.findHaxeFieldByName(childReferences[1].getText()));
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -459,6 +459,11 @@ public class HaxeResolveUtil {
       return result;
     }
 
+    result = HaxeAbstractEnumUtil.resolveFieldType(element);
+    if(result != null) {
+      return result;
+    }
+
     if (specialization.containsKey(null, element.getText())) {
       return specialization.get(null, element.getText());
     }

--- a/testData/annotation.semantic/NonConstantArgumentAbstractEnum.hx
+++ b/testData/annotation.semantic/NonConstantArgumentAbstractEnum.hx
@@ -1,0 +1,7 @@
+import test.SampleAbstractEnum;
+class NonConstantArgumentAbstractEnum {
+  function test1(arg:SampleAbstractEnum = SampleAbstractEnum.ONE) {}
+  function test3(arg:Dynamic = SampleAbstractEnum.THREE) {}
+  function test2(arg:Int = SampleAbstractEnum.TWO) {}
+  function test4(arg:SampleAbstractEnum = 4) {}
+}

--- a/testData/annotation.semantic/std/StdTypes.hx
+++ b/testData/annotation.semantic/std/StdTypes.hx
@@ -1,0 +1,17 @@
+extern enum Void { }
+extern class Float { }
+extern class Int extends Float { }
+typedef Null<T> = T
+extern enum Bool {
+  true;
+  false;
+}
+extern class Dynamic<T> { }
+typedef Iterator<T> = {
+  function hasNext() : Bool;
+  function next() : T;
+}
+typedef Iterable<T> = {
+  function iterator() : Iterator<T>;
+}
+extern interface ArrayAccess<T> { }

--- a/testData/annotation.semantic/test/SampleAbstractEnum.hx
+++ b/testData/annotation.semantic/test/SampleAbstractEnum.hx
@@ -1,0 +1,14 @@
+package test;
+
+@:enum abstract SampleAbstractEnum(Int) from Int to Int {
+  var ONE = 1;
+  public var TWO = 2;
+  var THREE:Int = 3;
+  public var FOUR:SampleAbstractEnum = 4;
+
+  static public var staticGetter(get, never):String;
+  static function get_staticGetter() return "5";
+
+  public var getter(get, never):String;
+  function get_getter() return "6";
+}

--- a/testData/completion/references/AbstractEnumFields.hx
+++ b/testData/completion/references/AbstractEnumFields.hx
@@ -1,0 +1,6 @@
+import com.util.SampleAbstractEnum;
+class AbstractEnumFields {
+  function new() {
+    SampleAbstractEnum.<caret>
+  }
+}

--- a/testData/completion/references/AbstractEnumFields.txt
+++ b/testData/completion/references/AbstractEnumFields.txt
@@ -1,0 +1,9 @@
+:INCLUDE
+ONE
+TWO
+THREE
+FOUR
+staticGetter
+
+:EXCLUDE
+getter

--- a/testData/completion/references/AbstractEnumFields2.hx
+++ b/testData/completion/references/AbstractEnumFields2.hx
@@ -1,0 +1,7 @@
+import com.util.SampleAbstractEnum;
+class AbstractEnumFields {
+  function new() {
+    var a = SampleAbstractEnum.ONE;
+    a.<caret>
+  }
+}

--- a/testData/completion/references/AbstractEnumFields2.txt
+++ b/testData/completion/references/AbstractEnumFields2.txt
@@ -1,0 +1,9 @@
+:INCLUDE
+getter
+
+:EXCLUDE
+ONE
+TWO
+THREE
+FOUR
+staticGetter

--- a/testData/completion/references/AbstractEnumFields3.hx
+++ b/testData/completion/references/AbstractEnumFields3.hx
@@ -1,0 +1,7 @@
+import com.util.SampleAbstractEnum;
+class AbstractEnumFields {
+  function new() {
+    var a = SampleAbstractEnum.THREE;
+    a.<caret>
+  }
+}

--- a/testData/completion/references/AbstractEnumFields3.txt
+++ b/testData/completion/references/AbstractEnumFields3.txt
@@ -1,0 +1,2 @@
+:EXCLUDE
+getter

--- a/testData/completion/references/AutodetectConstant.hx
+++ b/testData/completion/references/AutodetectConstant.hx
@@ -1,0 +1,10 @@
+class Methods {
+  public static inline var mybool3 = false;
+  public static inline var mybool4:Bool = false;
+}
+
+class Main {
+  public static function main() {
+    Methods.<caret>
+  }
+}

--- a/testData/completion/references/AutodetectConstant.txt
+++ b/testData/completion/references/AutodetectConstant.txt
@@ -1,0 +1,2 @@
+mybool3:Bool = false
+mybool4:Bool = false

--- a/testData/completion/references/AutodetectMethod.hx
+++ b/testData/completion/references/AutodetectMethod.hx
@@ -1,8 +1,6 @@
 class Methods {
   public var mybool1 = false;
   public var mybool2:Bool = false;
-  public inline var mybool3 = false;
-  public inline var mybool4:Bool = false;
   public function foo() return 10;
   public function foo2() {
     return 10.0;

--- a/testData/completion/references/AutodetectMethod.txt
+++ b/testData/completion/references/AutodetectMethod.txt
@@ -3,5 +3,3 @@ foo2():Float = 10.0
 foo3():Bool = true
 mybool1:Bool
 mybool2:Bool
-mybool3:Bool = false
-mybool4:Bool = false

--- a/testData/completion/references/com/util/SampleAbstractEnum.hx
+++ b/testData/completion/references/com/util/SampleAbstractEnum.hx
@@ -1,0 +1,14 @@
+package com.util;
+
+@:enum abstract SampleAbstractEnum(Int) from Int {
+  var ONE = 1;
+  public var TWO = 2;
+  var THREE:Int = 3;
+  public var FOUR:SampleAbstractEnum = 4;
+
+  static public var staticGetter(get, never):String;
+  static function get_staticGetter() return "5";
+
+  public var getter(get, never):String;
+  function get_getter() return "6";
+}

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -101,6 +101,10 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
     doTestNoFixWithWarnings();
   }
 
+  public void testNonConstantArgumentAbstractEnum() throws Exception {
+    doTestNoFixWithWarnings("test/SampleAbstractEnum.hx", "std/StdTypes.hx");
+  }
+
   public void testConstructorMustNotBeStatic() throws Exception {
     doTestNoFixWithWarnings();
   }

--- a/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
+++ b/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
@@ -225,6 +225,19 @@ public class ReferenceCompletionTest extends HaxeCompletionTestBase {
     doTestInclude();
   }
 
+  public void testAbstractEnumFields() throws Throwable {
+    doTestInclude("com/util/SampleAbstractEnum.hx");
+  }
+
+  public void testAbstractEnumFields2() throws Throwable {
+    doTestInclude("com/util/SampleAbstractEnum.hx");
+  }
+
+  //public void testUsingStringTools() throws Throwable {
+  //  myFixture.configureByFiles("UsingStringTools.hx", "std/StringTools.hx", "std/String.hx", "std/StdTypes.hx");
+  //  doTestVariantsInner("UsingStringTools.txt");
+  //}
+
   // @TODO: Temporarily disabled. Not being recognized for an unknown reason.
   /*
   public void testExtensionMethod1() throws Throwable {

--- a/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
+++ b/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
@@ -185,6 +185,10 @@ public class ReferenceCompletionTest extends HaxeCompletionTestBase {
     doTestInclude();
   }
 
+  public void testAutodetectConstant() throws Throwable {
+    doTestInclude();
+  }
+
   public void testAutodetectProperties() throws Throwable {
     doTestInclude();
   }

--- a/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
+++ b/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
@@ -233,6 +233,10 @@ public class ReferenceCompletionTest extends HaxeCompletionTestBase {
     doTestInclude("com/util/SampleAbstractEnum.hx");
   }
 
+  public void testAbstractEnumFields3() throws Throwable {
+    doTestInclude("com/util/SampleAbstractEnum.hx");
+  }
+
   //public void testUsingStringTools() throws Throwable {
   //  myFixture.configureByFiles("UsingStringTools.hx", "std/StringTools.hx", "std/String.hx", "std/StdTypes.hx");
   //  doTestVariantsInner("UsingStringTools.txt");


### PR DESCRIPTION
- Fix for Issue #427 - Abstract Enum auto-completion
- Fix for Issue #428 - Abstract Enum fields type resolving
- Fix for Issue #429 - Annotator for constant initializer in default arguments
- Fix AutodetectMethods unit-test `inline var` fields: haxe doesn't compile that, only `static inline var` is allowed for constants
- Fix in HaxeClassReference instantiation from model instance - should remember class model, otherwise some annotations don't work

Please review, after that release notes could be added.

*NOTES: I've tried to not change a lot of code-base, and localize main logic in HaxeAbstractEnumUtil, but without minimal amount of main codebase fixes - the main Abstract Enum support will not work.*
