### PR TITLE
Typedef generic params basic completion and resolving (Issue #304)

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -40,6 +40,7 @@
         <li>Better packages resolving</li>
         <li>Fix catch parameter declaration (issue #419)</li>
         <li>Fix inherited type in field initializer (issue #412)</li>
+        <li>Fix typedef generic params resolving (issue #304)</li>
       </ul>
       <p>0.9.9: (community release)</p>
       <ul>

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxePsiClass.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxePsiClass.java
@@ -79,9 +79,9 @@ public abstract class AbstractHaxePsiClass extends AbstractHaxeNamedComponent im
 
     if(name == null && this instanceof HaxeAnonymousType) {
       // restore name from parent
-      HaxeTypedefDeclaration typedefDecl = (HaxeTypedefDeclaration)(getParent().getParent());
-      if(typedefDecl != null) {
-        name = typedefDecl.getName();
+      final PsiElement typedefDecl = getParent().getParent();
+      if(typedefDecl != null && typedefDecl instanceof HaxeTypedefDeclaration) {
+        name = ((HaxeTypedefDeclaration)typedefDecl).getName();
       }
     }
 

--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -424,7 +424,7 @@ public class HaxeResolveUtil {
     if (element instanceof HaxeComponentName) {
       return getHaxeClassResolveResult(element.getParent(), specialization);
     }
-    if (element instanceof AbstractHaxeTypeDefImpl) {
+    if (element instanceof HaxeTypedefDeclaration) {
       final AbstractHaxeTypeDefImpl typeDef = (AbstractHaxeTypeDefImpl)element;
       return typeDef.getTargetClass(specialization);
     }
@@ -485,6 +485,12 @@ public class HaxeResolveUtil {
     HaxeClass haxeClass = type == null ? null : tryResolveClassByQName(type);
     if (haxeClass == null && type != null && specialization.containsKey(element, type.getText())) {
       return specialization.get(element, type.getText());
+    }
+
+    if(haxeClass instanceof HaxeTypedefDeclaration) {
+      HaxeClassResolveResult temp = HaxeClassResolveResult.create(haxeClass, specialization);
+      temp.specializeByParameters(type.getTypeParam());
+      specialization = temp.getSpecialization();
     }
 
     HaxeClassResolveResult result = getHaxeClassResolveResult(haxeClass, specialization.getInnerSpecialization(element));

--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -424,7 +424,7 @@ public class HaxeResolveUtil {
     if (element instanceof HaxeComponentName) {
       return getHaxeClassResolveResult(element.getParent(), specialization);
     }
-    if (element instanceof HaxeTypedefDeclaration) {
+    if (element instanceof AbstractHaxeTypeDefImpl) {
       final AbstractHaxeTypeDefImpl typeDef = (AbstractHaxeTypeDefImpl)element;
       return typeDef.getTargetClass(specialization);
     }

--- a/testData/completion/references/NullTypedef.hx
+++ b/testData/completion/references/NullTypedef.hx
@@ -1,11 +1,5 @@
-typedef Null<T> = T;
-class Bar<T> {
-  public var s:T;
-}
-
 class Main {
-  function foo() {
-    var a:Null<String>;
+  function foo(a:Null<String>) {
     a.<caret>
   }
 }

--- a/testData/completion/references/NullTypedef.hx
+++ b/testData/completion/references/NullTypedef.hx
@@ -1,0 +1,11 @@
+typedef Null<T> = T;
+class Bar<T> {
+  public var s:T;
+}
+
+class Main {
+  function foo() {
+    var a:Null<String>;
+    a.<caret>
+  }
+}

--- a/testData/completion/references/NullTypedef.txt
+++ b/testData/completion/references/NullTypedef.txt
@@ -1,0 +1,2 @@
+BASIC 1 INCLUDES
+split

--- a/testData/completion/references/RefTypedef.hx
+++ b/testData/completion/references/RefTypedef.hx
@@ -1,0 +1,9 @@
+typedef Ref<T> = {
+  function get():T;
+}
+
+class Main {
+  function foo(a:Ref<String>) {
+    a.get().<caret>
+  }
+}

--- a/testData/completion/references/RefTypedef.txt
+++ b/testData/completion/references/RefTypedef.txt
@@ -1,0 +1,2 @@
+BASIC 1 INCLUDES
+split

--- a/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
+++ b/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
@@ -230,6 +230,11 @@ public class ReferenceCompletionTest extends HaxeCompletionTestBase {
     doTestVariantsInner("NullTypedef.txt");
   }
 
+  public void testRefTypedef() throws Throwable {
+    myFixture.configureByFiles("RefTypedef.hx", "std/String.hx");
+    doTestVariantsInner("RefTypedef.txt");
+  }
+
   // @TODO: Temporarily disabled. Not being recognized for an unknown reason.
   /*
   public void testExtensionMethod1() throws Throwable {

--- a/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
+++ b/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
@@ -225,6 +225,11 @@ public class ReferenceCompletionTest extends HaxeCompletionTestBase {
     doTestInclude();
   }
 
+  public void testNullTypedef() throws Throwable {
+    myFixture.configureByFiles("NullTypedef.hx", "std/StdTypes.hx", "std/String.hx");
+    doTestVariantsInner("NullTypedef.txt");
+  }
+
   // @TODO: Temporarily disabled. Not being recognized for an unknown reason.
   /*
   public void testExtensionMethod1() throws Throwable {


### PR DESCRIPTION
Has been created to fix issue #304
- Typedef declaration types as `typedef Null<T> = T`

![image](https://cloud.githubusercontent.com/assets/3038174/13267724/e94445ae-da8f-11e5-9fb5-c40370355b80.png)
- Typedef structures as `typedef Ref<T> = { function get():T; }`

![image](https://cloud.githubusercontent.com/assets/3038174/13267819/4a13dba6-da90-11e5-931a-d17dc7fe4824.png)
- Tests added, release notes added
- Fix unhandled exception while restoring type name for anonymous type body from parent