### PR TITLE
Fix import generic sub-types resolving from regular module import (Issue #435)

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -41,6 +41,7 @@
         <li>Fix catch parameter declaration (issue #419)</li>
         <li>Fix inherited type in field initializer (issue #412)</li>
         <li>Delete single-class file in one operation from Project View (issue #424)</li>
+        <li>Fix generic sub-type resolving when import just type-module (issue #435)</li>
       </ul>
       <p>0.9.9: (community release)</p>
       <ul>

--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -594,6 +594,7 @@ public class HaxeResolveUtil {
 
   @Nullable
   private static HaxeClass tryFindHelper(PsiElement element) {
+    // FIXME: don't use getText(), find "Ref" instead of "Ref<String>"
     final HaxeClass ownerClass = findClassByQName(UsefulPsiTreeUtil.findHelperOwnerQName(element, element.getText()), element);
     return ownerClass == null ? null : findComponentDeclaration(ownerClass.getContainingFile(), element.getText());
   }

--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -594,9 +594,13 @@ public class HaxeResolveUtil {
 
   @Nullable
   private static HaxeClass tryFindHelper(PsiElement element) {
-    // FIXME: don't use getText(), find "Ref" instead of "Ref<String>"
-    final HaxeClass ownerClass = findClassByQName(UsefulPsiTreeUtil.findHelperOwnerQName(element, element.getText()), element);
-    return ownerClass == null ? null : findComponentDeclaration(ownerClass.getContainingFile(), element.getText());
+    // issue #435: don't use getText(), find "Ref" instead of "Ref<String>"
+    String className = element.getText();
+    if (element instanceof HaxeType) {
+      className = ((HaxeType)element).getReferenceExpression().getText();
+    }
+    final HaxeClass ownerClass = findClassByQName(UsefulPsiTreeUtil.findHelperOwnerQName(element, className), element);
+    return ownerClass == null ? null : findComponentDeclaration(ownerClass.getContainingFile(), className);
   }
 
   @Nullable

--- a/testData/completion/references/ImportGenericSubType.hx
+++ b/testData/completion/references/ImportGenericSubType.hx
@@ -1,0 +1,6 @@
+import generic1.ClassWithGenericSubClass;
+class ImportGenericSubType {
+  function new(a:GenericSubClass<Int>){
+    a.<caret>
+  }
+}

--- a/testData/completion/references/ImportGenericSubType.txt
+++ b/testData/completion/references/ImportGenericSubType.txt
@@ -1,0 +1,2 @@
+BASIC 1 INCLUDES
+foo

--- a/testData/completion/references/generic1/ClassWithGenericSubClass.hx
+++ b/testData/completion/references/generic1/ClassWithGenericSubClass.hx
@@ -1,0 +1,5 @@
+package generic1;
+class ClassWithGenericSubClass {}
+class GenericSubClass<T> {
+  public function foo() {}
+}

--- a/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
+++ b/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
@@ -225,6 +225,11 @@ public class ReferenceCompletionTest extends HaxeCompletionTestBase {
     doTestInclude();
   }
 
+  public void testImportGenericSubType() throws Throwable {
+    myFixture.configureByFiles("ImportGenericSubType.hx", "generic1/ClassWithGenericSubClass.hx", "std/StdTypes.hx");
+    doTestVariantsInner("ImportGenericSubType.txt");
+  }
+
   // @TODO: Temporarily disabled. Not being recognized for an unknown reason.
   /*
   public void testExtensionMethod1() throws Throwable {


### PR DESCRIPTION
- Fix the issue with generic sub-types importing with natural short notation (issue #435)
- Unit test added
- Release notes updated

**Before:**
![image](https://cloud.githubusercontent.com/assets/3038174/13294657/0b9724d6-db36-11e5-9f73-fe05cb822ab6.png)

**After:**
Completion:
![image](https://cloud.githubusercontent.com/assets/3038174/13294668/20b24e54-db36-11e5-8f27-8918873fd1b1.png)
Resolving: 
![image](https://cloud.githubusercontent.com/assets/3038174/13294722/5d1e9d70-db36-11e5-82dc-b9134c14272b.png)

