### PR TITLE
Fix class name completion for import/using statements (Issue #286)

### DIFF
--- a/.idea/ant.xml
+++ b/.idea/ant.xml
@@ -3,8 +3,10 @@
   <component name="AntConfiguration">
     <buildFile url="file://$PROJECT_DIR$/build-test.xml" />
     <buildFile url="file://$PROJECT_DIR$/build.xml" />
+    <buildFile url="file://$PROJECT_DIR$/local-build-overrides.xml" />
     <buildFile url="file://$PROJECT_DIR$/common.xml">
       <executeOn event="beforeCompilation" target="generateTemplatedFiles" />
     </buildFile>
   </component>
 </project>
+

--- a/.idea/ant.xml
+++ b/.idea/ant.xml
@@ -3,10 +3,8 @@
   <component name="AntConfiguration">
     <buildFile url="file://$PROJECT_DIR$/build-test.xml" />
     <buildFile url="file://$PROJECT_DIR$/build.xml" />
-    <buildFile url="file://$PROJECT_DIR$/local-build-overrides.xml" />
     <buildFile url="file://$PROJECT_DIR$/common.xml">
       <executeOn event="beforeCompilation" target="generateTemplatedFiles" />
     </buildFile>
   </component>
 </project>
-

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -41,6 +41,7 @@
         <li>Fix catch parameter declaration (issue #419)</li>
         <li>Fix inherited type in field initializer (issue #412)</li>
         <li>Delete single-class file in one operation from Project View (issue #424)</li>
+        <li>Fix import / using statements class name completion (issue #286)</li>
       </ul>
       <p>0.9.9: (community release)</p>
       <ul>


### PR DESCRIPTION
This PR fix very annoying #286 issue:

- Added new completion mode for using / import statements
- Added new InsertHandler to deal with replacing typed identifier to full qualified class name (import path)
- Release notes updated

![feb 25 2016 13 46](https://cloud.githubusercontent.com/assets/3038174/13317409/37f937cc-dbc6-11e5-8249-889cedb7e7aa.gif)
