### PR TITLE
Incorrect public override (Issue #439)

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -41,6 +41,7 @@
         <li>Fix catch parameter declaration (issue #419)</li>
         <li>Fix inherited type in field initializer (issue #412)</li>
         <li>Delete single-class file in one operation from Project View (issue #424)</li>
+        <li>Incorrect “public” modifier when override methods fixed (issue #439)</li>
       </ul>
       <p>0.9.9: (community release)</p>
       <ul>

--- a/src/common/com/intellij/plugins/haxe/ide/generation/OverrideImplementMethodFix.java
+++ b/src/common/com/intellij/plugins/haxe/ide/generation/OverrideImplementMethodFix.java
@@ -24,6 +24,8 @@ import com.intellij.plugins.haxe.lang.psi.HaxeDeclarationAttribute;
 import com.intellij.plugins.haxe.lang.psi.HaxeNamedComponent;
 import com.intellij.plugins.haxe.lang.psi.HaxeTypeTag;
 import com.intellij.plugins.haxe.util.HaxePresentableUtil;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiMember;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.Function;
 
@@ -42,7 +44,11 @@ public class OverrideImplementMethodFix extends BaseCreateMethodsFix<HaxeNamedCo
   protected String buildFunctionsText(HaxeNamedComponent element) {
     final HaxeComponentType componentType = HaxeComponentType.typeOf(element);
     final StringBuilder result = new StringBuilder();
-    if (override && !element.isOverride()) {
+
+    final PsiClass containingClass = element instanceof PsiMember ? ((PsiMember)element).getContainingClass() : null;
+    final boolean isInterfaceElement = containingClass != null && containingClass.isInterface();
+
+    if (!isInterfaceElement && override && !element.isOverride()) {
       result.append("override ");
     }
     final HaxeDeclarationAttribute[] declarationAttributeList = PsiTreeUtil.getChildrenOfType(element, HaxeDeclarationAttribute.class);
@@ -55,7 +61,7 @@ public class OverrideImplementMethodFix extends BaseCreateMethodsFix<HaxeNamedCo
       }, " "));
       result.append(" ");
     }
-    if (!result.toString().contains("public")) {
+    if (isInterfaceElement && !result.toString().contains("public")) {
       result.insert(0, "public ");
     }
     if (componentType == HaxeComponentType.FIELD) {


### PR DESCRIPTION
https://github.com/TiVo/intellij-haxe/issues/439
Was:
[![https://gyazo.com/33e974fcc6063a369a2fcaeb8ab2292f](https://i.gyazo.com/33e974fcc6063a369a2fcaeb8ab2292f.png)](https://gyazo.com/33e974fcc6063a369a2fcaeb8ab2292f)
Now:
[![https://gyazo.com/ecb828e7677c1eb0d26224324406aa7e](https://i.gyazo.com/ecb828e7677c1eb0d26224324406aa7e.png)](https://gyazo.com/ecb828e7677c1eb0d26224324406aa7e)
“public”s for interfaces handled.