### PR TITLE
Fix use scope and highlighting for declarations (Issue #235)

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -41,6 +41,7 @@
         <li>Fix catch parameter declaration (issue #419)</li>
         <li>Fix inherited type in field initializer (issue #412)</li>
         <li>Delete single-class file in one operation from Project View (issue #424)</li>
+        <li>Fix use scope for var declarations (issue #235)</li>
       </ul>
       <p>0.9.9: (community release)</p>
       <ul>

--- a/src/common/com/intellij/plugins/haxe/lang/psi/HaxeForStatementPsiMixin.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/HaxeForStatementPsiMixin.java
@@ -17,6 +17,8 @@
  */
 package com.intellij.plugins.haxe.lang.psi;
 
+import com.intellij.psi.PsiNameIdentifierOwner;
+
 /**
  * We need a mixin specifically for the 'for' statement in order for it
  * to be both a statement and an AbstractHaxeNamedComponent.  The
@@ -26,7 +28,7 @@ package com.intellij.plugins.haxe.lang.psi;
  * See HaxePsiCompositeElementImpl.getDeclarationToProcess() to see how
  * that works.
  */
-public interface HaxeForStatementPsiMixin extends HaxeStatementPsiMixin {
+public interface HaxeForStatementPsiMixin extends HaxeStatementPsiMixin, PsiNameIdentifierOwner {
 
   // The funny thing is that we don't need any interfaces at this level.
   // We just need to introduce a specific inheritance.

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeForStatementPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeForStatementPsiMixinImpl.java
@@ -18,7 +18,10 @@
 package com.intellij.plugins.haxe.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.plugins.haxe.lang.psi.HaxeComponentName;
 import com.intellij.plugins.haxe.lang.psi.HaxeForStatementPsiMixin;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Created by ebishton on 12/4/14.
@@ -27,6 +30,13 @@ public abstract class HaxeForStatementPsiMixinImpl extends AbstractHaxeNamedComp
 
   public HaxeForStatementPsiMixinImpl(ASTNode node) {
     super(node);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getNameIdentifier() {
+    final HaxeComponentName componentName = getComponentName();
+    return componentName != null ? componentName.getNameIdentifier() : null;
   }
 
 }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.model.HaxeMethodModel;
+import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.PsiImplUtil;
 import com.intellij.psi.impl.PsiSuperMethodImplUtil;
@@ -349,7 +350,10 @@ public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent 
   @Override
   public SearchScope getUseScope() {
     if(this instanceof HaxeLocalFunctionDeclaration) {
-      return new LocalSearchScope(getParent());
+      final PsiElement outerBlock = UsefulPsiTreeUtil.getParentOfType(this, HaxeBlockStatement.class);
+      if(outerBlock != null) {
+        return new LocalSearchScope(outerBlock);
+      }
     }
     return super.getUseScope();
   }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
@@ -27,6 +27,8 @@ import com.intellij.psi.*;
 import com.intellij.psi.impl.PsiImplUtil;
 import com.intellij.psi.impl.PsiSuperMethodImplUtil;
 import com.intellij.psi.javadoc.PsiDocComment;
+import com.intellij.psi.search.LocalSearchScope;
+import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.util.MethodSignature;
 import com.intellij.psi.util.MethodSignatureBackedByPsiMethod;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -223,15 +225,8 @@ public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent 
   @Nullable
   @Override
   public PsiIdentifier getNameIdentifier() {
-    PsiIdentifier foundName = null;
-    ASTNode node = getNode();
-    if (null != node) {
-      ASTNode element = node.findChildByType(HaxeTokenTypes.IDENTIFIER);
-      if (null != element) {
-        foundName = (PsiIdentifier) element.getPsi();
-      }
-    }
-    return foundName;
+    final HaxeComponentName componentName = getComponentName();
+    return componentName != null ? componentName.getIdentifier() : null;
   }
 
   @NotNull
@@ -348,5 +343,14 @@ public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent 
   public PsiParameterList getParameterList() {
     final HaxeParameterList list = PsiTreeUtil.getChildOfType(this, HaxeParameterList.class);
     return ((list != null) ? list : new HaxeParameterListImpl(new HaxeDummyASTNode("Dummy parameter list")));
+  }
+
+  @NotNull
+  @Override
+  public SearchScope getUseScope() {
+    if(this instanceof HaxeLocalFunctionDeclaration) {
+      return new LocalSearchScope(getParent());
+    }
+    return super.getUseScope();
   }
 }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeNamedElementImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeNamedElementImpl.java
@@ -95,7 +95,7 @@ public abstract class HaxeNamedElementImpl extends HaxePsiCompositeElementImpl i
       return super.getUseScope();
     }
     if (type == HaxeComponentType.FUNCTION || type == HaxeComponentType.PARAMETER || type == HaxeComponentType.VARIABLE) {
-      return new LocalSearchScope(component);
+      return new LocalSearchScope(component.getParent());
     }
     return super.getUseScope();
   }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeParameterPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeParameterPsiMixinImpl.java
@@ -20,10 +20,7 @@ package com.intellij.plugins.haxe.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.plugins.haxe.lang.psi.HaxeModifierList;
-import com.intellij.plugins.haxe.lang.psi.HaxeParameter;
-import com.intellij.plugins.haxe.lang.psi.HaxeParameterPsiMixin;
-import com.intellij.plugins.haxe.lang.psi.HaxePsiModifier;
+import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.psi.*;
 import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NonNls;
@@ -155,8 +152,8 @@ public abstract class HaxeParameterPsiMixinImpl extends AbstractHaxeNamedCompone
   @Nullable
   @Override
   public PsiIdentifier getNameIdentifier() {
-    // TODO:  Implement 'public PsiIdentifier getNameIdentifier()'
-    return null;
+    final HaxeComponentName componentName = getComponentName();
+    return componentName != null ? componentName.getIdentifier() : null;
   }
 
   @NotNull

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
@@ -24,6 +24,8 @@ import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.psi.*;
 import com.intellij.psi.javadoc.PsiDocComment;
+import com.intellij.psi.search.LocalSearchScope;
+import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.IncorrectOperationException;
 import org.apache.log4j.Level;
@@ -204,4 +206,19 @@ public abstract class HaxePsiFieldImpl extends AbstractHaxeNamedComponent implem
     return this.getModifierList().hasModifierProperty(name);
   }
 
+  @NotNull
+  @Override
+  public SearchScope getUseScope() {
+    final PsiElement parent = getParent();
+    if(parent != null) {
+      if (this instanceof HaxeLocalVarDeclarationPart) {
+        // parent of local var declaration-Part
+        return new LocalSearchScope(parent.getParent());
+      }
+      else if (this instanceof HaxeLocalVarDeclaration) {
+        return new LocalSearchScope(parent);
+      }
+    }
+    return super.getUseScope();
+  }
 }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
@@ -62,25 +62,16 @@ public abstract class HaxePsiFieldImpl extends AbstractHaxeNamedComponent implem
   }
 
   @Override
-  @NotNull
+  @Nullable
   public HaxeComponentName getComponentName() {
-    return new HaxeComponentNameImpl(getNode());
-    ////this.getName();
-    //return findNotNullChildByClass(HaxeComponentName.class);
+    return null;
   }
 
   @Nullable
   @Override
   public PsiIdentifier getNameIdentifier() {
-    PsiIdentifier foundName = null;
-    ASTNode node = getNode();
-    if (null != node) {
-      ASTNode element = node.findChildByType(HaxeTokenTypes.IDENTIFIER);
-      if (null != element) {
-        foundName = (PsiIdentifier) element.getPsi();
-      }
-    }
-    return foundName;
+    HaxeComponentName name = getComponentName();
+    return name != null ? name.getIdentifier() : null;
   }
 
   @Nullable

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
@@ -67,14 +67,15 @@ public abstract class HaxePsiFieldImpl extends AbstractHaxeNamedComponent implem
   @Override
   @Nullable
   public HaxeComponentName getComponentName() {
-    return null;
+    final PsiIdentifier identifier = getNameIdentifier();
+    return identifier != null ? new HaxeComponentNameImpl(getNode()) : null;
   }
 
   @Nullable
   @Override
   public PsiIdentifier getNameIdentifier() {
-    HaxeComponentName name = getComponentName();
-    return name != null ? name.getIdentifier() : null;
+    final HaxeComponentName compName = PsiTreeUtil.getChildOfType(this, HaxeComponentName.class);
+    return compName != null ? PsiTreeUtil.getChildOfType(compName, HaxeIdentifier.class) : null;
   }
 
   @Nullable
@@ -212,7 +213,10 @@ public abstract class HaxePsiFieldImpl extends AbstractHaxeNamedComponent implem
   public SearchScope getUseScope() {
     final PsiElement localVar = UsefulPsiTreeUtil.getParentOfType(this, HaxeLocalVarDeclaration.class);
     if(localVar != null) {
-      return new LocalSearchScope(localVar.getParent());
+      final PsiElement outerBlock = UsefulPsiTreeUtil.getParentOfType(localVar, HaxeBlockStatement.class);
+      if(outerBlock != null) {
+        return new LocalSearchScope(outerBlock);
+      }
     }
     return super.getUseScope();
   }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
@@ -22,6 +22,7 @@ import com.intellij.lang.ASTNode;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
 import com.intellij.psi.*;
 import com.intellij.psi.javadoc.PsiDocComment;
 import com.intellij.psi.search.LocalSearchScope;
@@ -209,15 +210,9 @@ public abstract class HaxePsiFieldImpl extends AbstractHaxeNamedComponent implem
   @NotNull
   @Override
   public SearchScope getUseScope() {
-    final PsiElement parent = getParent();
-    if(parent != null) {
-      if (this instanceof HaxeLocalVarDeclarationPart) {
-        // parent of local var declaration-Part
-        return new LocalSearchScope(parent.getParent());
-      }
-      else if (this instanceof HaxeLocalVarDeclaration) {
-        return new LocalSearchScope(parent);
-      }
+    final PsiElement localVar = UsefulPsiTreeUtil.getParentOfType(this, HaxeLocalVarDeclaration.class);
+    if(localVar != null) {
+      return new LocalSearchScope(localVar.getParent());
     }
     return super.getUseScope();
   }

--- a/testData/rename/ForVar.hx
+++ b/testData/rename/ForVar.hx
@@ -1,0 +1,8 @@
+class Bar {
+  public function new() {}
+  function doSomething():String return "";
+}
+class Foo {
+  var a:Bar = new Bar();
+  function printNtimes(msg:String, n:Int):Void for(a in 0...n) trace(a<caret> + ":" + msg);
+}

--- a/testData/rename/ForVarAfter.hx
+++ b/testData/rename/ForVarAfter.hx
@@ -1,0 +1,8 @@
+class Bar {
+  public function new() {}
+  function doSomething():String return "";
+}
+class Foo {
+  var a:Bar = new Bar();
+  function printNtimes(msg:String, n:Int):Void for(index in 0...n) trace(index + ":" + msg);
+}

--- a/testData/rename/FunctionParameter.hx
+++ b/testData/rename/FunctionParameter.hx
@@ -1,5 +1,5 @@
 class FunctionParameter {
-  function bar(foo:LocalVariable){
+  function bar(foo:FunctionParameter){
     fo<caret>o;
   }
 }

--- a/testData/rename/FunctionParameterAfter.hx
+++ b/testData/rename/FunctionParameterAfter.hx
@@ -1,5 +1,5 @@
 class FunctionParameter {
-  function bar(fooNew:LocalVariable1){
+  function bar(fooNew:FunctionParameter){
     fooNew;
   }
 }

--- a/testData/rename/FunctionParameterAfter.hx
+++ b/testData/rename/FunctionParameterAfter.hx
@@ -1,5 +1,5 @@
 class FunctionParameter {
-  function bar(fooNew:LocalVariable){
+  function bar(fooNew:LocalVariable1){
     fooNew;
   }
 }

--- a/testData/rename/LocalVariable.hx
+++ b/testData/rename/LocalVariable.hx
@@ -1,6 +1,0 @@
-class LocalVariable {
-  function bar(){
-    var foo:LocalVariable;
-    fo<caret>o = new LocalVariable();
-  }
-}

--- a/testData/rename/LocalVariable1.hx
+++ b/testData/rename/LocalVariable1.hx
@@ -1,0 +1,6 @@
+class LocalVariable1 {
+  function bar(){
+    var foo:LocalVariable1;
+    f<caret>oo = new LocalVariable1();
+  }
+}

--- a/testData/rename/LocalVariable1After.hx
+++ b/testData/rename/LocalVariable1After.hx
@@ -1,0 +1,6 @@
+class LocalVariable1 {
+  function bar(){
+    var fooNew:LocalVariable1;
+    fooNew = new LocalVariable1();
+  }
+}

--- a/testData/rename/LocalVariable2.hx
+++ b/testData/rename/LocalVariable2.hx
@@ -1,0 +1,6 @@
+class LocalVariable2 {
+  function bar(){
+    var fo<caret>o:LocalVariable2;
+    foo = new LocalVariable2();
+  }
+}

--- a/testData/rename/LocalVariable2After.hx
+++ b/testData/rename/LocalVariable2After.hx
@@ -1,0 +1,6 @@
+class LocalVariable2 {
+  function bar(){
+    var fooNew:LocalVariable2;
+    fooNew = new LocalVariable2();
+  }
+}

--- a/testData/rename/LocalVariableAfter.hx
+++ b/testData/rename/LocalVariableAfter.hx
@@ -1,6 +1,0 @@
-class LocalVariable {
-  function bar(){
-    var fooNew:LocalVariable;
-    fooNew = new LocalVariable();
-  }
-}

--- a/testSrc/com/intellij/plugins/haxe/actions/HaxeRenameTest.java
+++ b/testSrc/com/intellij/plugins/haxe/actions/HaxeRenameTest.java
@@ -32,7 +32,11 @@ public class HaxeRenameTest extends HaxeCodeInsightFixtureTestCase {
     myFixture.testRename(getTestName(false) + ".hx", getTestName(false) + "After.hx", newName, additionalFiles);
   }
 
-  public void testLocalVariable() throws Throwable {
+  public void testLocalVariable1() throws Throwable {
+    doTest("fooNew");
+  }
+
+  public void testLocalVariable2() throws Throwable {
     doTest("fooNew");
   }
 

--- a/testSrc/com/intellij/plugins/haxe/actions/HaxeRenameTest.java
+++ b/testSrc/com/intellij/plugins/haxe/actions/HaxeRenameTest.java
@@ -63,4 +63,8 @@ public class HaxeRenameTest extends HaxeCodeInsightFixtureTestCase {
   public void testCatchParameter() throws Throwable {
     doTest("error");
   }
+
+  public void testForVar() throws Throwable {
+    doTest("index");
+  }
 }


### PR DESCRIPTION
This PR will fix highlighting issue #235 and will fix renaming from parameter or local var/function declarations.

- Fixed usage scope for variables/functions/parameters declaration psi elements.
- Highlighting from usage to declaration fixed
- Renaming from declaration parameter fixed (test case added)
- Unit test added for renaming which isn't work on previous implementation
- Release notes updated

**Before:**
![image](https://cloud.githubusercontent.com/assets/3038174/13331904/a326d208-dc10-11e5-9e51-456f4731524f.png)
![image](https://cloud.githubusercontent.com/assets/3038174/13331921/b4e98f3a-dc10-11e5-8deb-8d41ab2c8cd8.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/3038174/13331824/547b499a-dc10-11e5-869d-0088da2745c1.png)
![image](https://cloud.githubusercontent.com/assets/3038174/13331837/64241430-dc10-11e5-971a-9a4883207748.png)

