### PR TITLE
[FindUsages] Import filtering (Issue #426)

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -51,6 +51,7 @@
         <li>Incorrect “public” modifier when override methods fixed (issue #439)</li>
         <li>Incorrect field access modifier after action generate set/get methods. Can't use action generate set/get methods for static fields. (TiVo Issue #442)</li>
         <li>Fix use scope for var declarations (issue #235)</li>
+        <li>Find usages import filtering (issue #426)</li>
       </ul>
       <p>0.9.9: (community release)</p>
       <ul>
@@ -689,6 +690,8 @@
                     serviceImplementation="com.intellij.plugins.haxe.lang.psi.HaxeClassResolveCache"/>
     <projectConfigurable instance="com.intellij.plugins.haxe.config.HaxeSettingsConfigurable" id="haxe.settings" key="haxe.settings.name"
                          bundle="com.intellij.plugins.haxe.HaxeBundle" nonDefaultProject="true"/>
+
+    <importFilteringRule implementation="com.intellij.plugins.haxe.ide.HaxeImportFilteringRule"/>
 
     <annotator language="Haxe" implementationClass="com.intellij.plugins.haxe.ide.annotator.HaxeColorAnnotator"/>
     <annotator language="Haxe" implementationClass="com.intellij.plugins.haxe.ide.annotator.HaxeTypeAnnotator"/>

--- a/src/common/com/intellij/plugins/haxe/ide/HaxeImportFilteringRule.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HaxeImportFilteringRule.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2016 AS3Boyan
+ * Copyright 2014-2014 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.ide;
+
+import com.intellij.plugins.haxe.HaxeFileType;
+import com.intellij.plugins.haxe.lang.psi.HaxeImportStatementRegular;
+import com.intellij.plugins.haxe.lang.psi.HaxeImportStatementWithInSupport;
+import com.intellij.plugins.haxe.lang.psi.HaxeImportStatementWithWildcard;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.usages.Usage;
+import com.intellij.usages.rules.ImportFilteringRule;
+import com.intellij.usages.rules.PsiElementUsage;
+import org.jetbrains.annotations.NotNull;
+
+public class HaxeImportFilteringRule extends ImportFilteringRule {
+
+  private static final Class[] IMPORT_STATEMENTS = new Class[]{
+    HaxeImportStatementRegular.class,
+    HaxeImportStatementWithInSupport.class,
+    HaxeImportStatementWithWildcard.class
+  };
+
+  @Override
+  public boolean isVisible(@NotNull Usage usage) {
+    if (usage instanceof PsiElementUsage) {
+      final PsiElement psiElement = ((PsiElementUsage)usage).getElement();
+      final PsiFile containingFile = psiElement.getContainingFile();
+
+      if (containingFile != null && containingFile.getFileType() == HaxeFileType.HAXE_FILE_TYPE) {
+        return PsiTreeUtil.getParentOfType(psiElement, IMPORT_STATEMENTS) == null;
+      }
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
PR enable possibility to hide usages in import statements when "find usage" is performing, required in issue #426
- Import filtering rule implemented
- Release notes updated

![importfiltering](https://cloud.githubusercontent.com/assets/3038174/13424695/659b4882-dfb3-11e5-926f-deb8506b2f85.gif)
