### PR TITLE
Forwarding abstract fields not resolved. Autocomplete don't work for forwarding abstract fields. (issue #447)

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -52,6 +52,7 @@
         <li>Incorrect field access modifier after action generate set/get methods. Can't use action generate set/get methods for static fields. (TiVo Issue #442)</li>
         <li>Fix use scope for var declarations (issue #235)</li>
         <li>Find usages import filtering (issue #426)</li>
+        <li>Forwarding abstract fields not resolved. Autocomplete don't work for forwarding abstract fields. (issue #447)</li>
       </ul>
       <p>0.9.9: (community release)</p>
       <ul>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -53,6 +53,7 @@
         <li>Fix use scope for var declarations (issue #235)</li>
         <li>Find usages import filtering (issue #426)</li>
         <li>Forwarding abstract fields not resolved. Autocomplete don't work for forwarding abstract fields. (issue #447)</li>
+        <li>@:forward not helps to resolve symbols in abstracts (issue #108)</li>
       </ul>
       <p>0.9.9: (community release)</p>
       <ul>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -52,8 +52,7 @@
         <li>Incorrect field access modifier after action generate set/get methods. Can't use action generate set/get methods for static fields. (TiVo Issue #442)</li>
         <li>Fix use scope for var declarations (issue #235)</li>
         <li>Find usages import filtering (issue #426)</li>
-        <li>Forwarding abstract fields not resolved. Autocomplete don't work for forwarding abstract fields. (issue #447)</li>
-        <li>@:forward not helps to resolve symbols in abstracts (issue #108)</li>
+        <li>Fix forwarding abstract fields completion and resolving. (issue #447, #108)</li>
       </ul>
       <p>0.9.9: (community release)</p>
       <ul>

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -763,6 +763,19 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
 
     boolean extern = haxeClass.isExtern();
     boolean isAbstractEnum = HaxeAbstractEnumUtil.isAbstractEnum(haxeClass);
+    boolean isAbstractForward = HaxeAbstractForwardUtil.isAbstractForward(haxeClass);
+
+    if (isAbstractForward) {
+      final List<HaxeNamedComponent> forwardingHaxeNamedComponents = HaxeAbstractForwardUtil.findAbstractForwardingNamedSubComponents(haxeClass);
+      if (forwardingHaxeNamedComponents != null) {
+        for (HaxeNamedComponent namedComponent : forwardingHaxeNamedComponents) {
+          final boolean needFilter = filterByAccess && !namedComponent.isPublic();
+          if ((extern || !needFilter) && !namedComponent.isStatic() && namedComponent.getComponentName() != null) {
+            suggestedVariants.add(namedComponent.getComponentName());
+          }
+        }
+      }
+    }
 
     for (HaxeNamedComponent namedComponent : HaxeResolveUtil.findNamedSubComponents(haxeClass)) {
       final boolean needFilter = filterByAccess && !namedComponent.isPublic();

--- a/src/common/com/intellij/plugins/haxe/util/HaxeAbstractEnumUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeAbstractEnumUtil.java
@@ -36,18 +36,7 @@ public class HaxeAbstractEnumUtil {
 
   @Contract("null -> false")
   public static boolean isAbstractEnum(@Nullable PsiClass clazz) {
-    if(clazz != null && clazz instanceof HaxeAbstractClassDeclaration) {
-      final HaxeMacroClassList metaList = ((HaxeAbstractClassDeclaration)clazz).getMacroClassList();
-      final List<HaxeMacroClass> metas = metaList != null ? metaList.getMacroClassList() : null;
-      if(metas != null) {
-        for (HaxeMacroClass meta : metas) {
-          if (meta.getText().equals("@:enum")) {
-            return true;
-          }
-        }
-      }
-    }
-    return false;
+    return HaxeAbstractUtil.hasMeta(clazz, "@:enum");
   }
 
   /**

--- a/src/common/com/intellij/plugins/haxe/util/HaxeAbstractForwardUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeAbstractForwardUtil.java
@@ -19,6 +19,7 @@ package com.intellij.plugins.haxe.util;
 
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
@@ -33,6 +34,16 @@ public class HaxeAbstractForwardUtil {
   @Contract("null -> false")
   public static boolean isAbstractForward(@Nullable PsiClass clazz) {
     return HaxeAbstractUtil.hasMeta(clazz, "@:forward");
+  }
+
+  public static boolean isElementInForwardMeta(@Nullable PsiElement element) {
+    if (element != null) {
+      if (element instanceof HaxeCustomMeta) {
+        return element.getText().contains("@:forward(");
+      }
+      return isElementInForwardMeta(element.getParent());
+    }
+    return false;
   }
 
   @Nullable

--- a/src/common/com/intellij/plugins/haxe/util/HaxeAbstractForwardUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeAbstractForwardUtil.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2016 AS3Boyan
+ * Copyright 2014-2014 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.util;
+
+import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.psi.PsiClass;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Extensions for resolving and analyzing @:forward abstract meta
+ */
+public class HaxeAbstractForwardUtil {
+
+  @Contract("null -> false")
+  public static boolean isAbstractForward(@Nullable PsiClass clazz) {
+    return HaxeAbstractUtil.hasMeta(clazz, "@:forward");
+  }
+
+  @Nullable
+  public static List<HaxeNamedComponent> findAbstractForwardingNamedSubComponents(@Nullable PsiClass clazz) {
+    final List<String> forwardingFieldsNames = getAbstractForwardingFieldsNames(clazz);
+    if (forwardingFieldsNames != null) {
+      final HaxeClass underlyingClass = HaxeAbstractUtil.getAbstractUnderlyingClass(clazz);
+      if (underlyingClass != null) {
+        if (forwardingFieldsNames.isEmpty()) {
+          return HaxeResolveUtil.findNamedSubComponents(underlyingClass);
+        }
+        List<HaxeNamedComponent> haxeNamedComponentList = new LinkedList<HaxeNamedComponent>();
+        for (String fieldName : forwardingFieldsNames) {
+          HaxeNamedComponent component = HaxeResolveUtil.findNamedSubComponent(underlyingClass, fieldName);
+          if (component != null) {
+            haxeNamedComponentList.add(component);
+          }
+        }
+        return haxeNamedComponentList;
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  public static List<String> getAbstractForwardingFieldsNames(@Nullable PsiClass clazz) {
+    List<String> forwardingFields = new LinkedList<String>();
+    HaxeMacroClass meta = HaxeAbstractUtil.getMetaByName(clazz, "@:forward");
+    if (meta != null) {
+      HaxeCustomMeta customMeta = meta.getCustomMeta();
+      if (customMeta != null) {
+        HaxeExpressionList expressions = customMeta.getExpressionList();
+        if (expressions != null) {
+          for (HaxeExpression expr : expressions.getExpressionList()) {
+            final String name = expr.getText();
+            if (name != null && !name.isEmpty() && !forwardingFields.contains(name)) {
+              forwardingFields.add(name);
+            }
+          }
+        }
+        return forwardingFields;
+      }
+    }
+    return null;
+  }
+
+}

--- a/src/common/com/intellij/plugins/haxe/util/HaxeAbstractUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeAbstractUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2016 AS3Boyan
+ * Copyright 2014-2014 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.util;
+
+import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.psi.PsiClass;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Extensions for working with abstracts
+ */
+public class HaxeAbstractUtil {
+
+  public static boolean hasMeta(@Nullable PsiClass clazz, @Nullable String metaName) {
+    return getMetaByName(clazz, metaName) != null;
+  }
+
+  @Nullable
+  public static HaxeMacroClass getMetaByName(@Nullable PsiClass clazz, @Nullable String metaName) {
+    if(clazz != null && metaName != null && clazz instanceof HaxeAbstractClassDeclaration) {
+      final HaxeMacroClassList metaList = ((HaxeAbstractClassDeclaration)clazz).getMacroClassList();
+      final List<HaxeMacroClass> metas = metaList != null ? metaList.getMacroClassList() : null;
+      if(metas != null) {
+        for (HaxeMacroClass meta : metas) {
+          if (meta.getText().equals(metaName)|| meta.getText().contains(metaName + "(")) {
+            return meta;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  public static HaxeClass getAbstractUnderlyingClass(@Nullable PsiClass clazz) {
+    if (clazz != null && clazz instanceof HaxeAbstractClassDeclaration) {
+      final HaxeType underlyingType = ((HaxeAbstractClassDeclaration)clazz).getTypeOrAnonymous().getType();
+      if (underlyingType != null) {
+        final HaxeClassResolveResult result = underlyingType.getReferenceExpression().resolveHaxeClass();
+        if (result != null) {
+          return result.getHaxeClass();
+        }
+      }
+    }
+    return null;
+  }
+
+}

--- a/testData/completion/references/AbstractForward.hx
+++ b/testData/completion/references/AbstractForward.hx
@@ -1,0 +1,9 @@
+import com.util.UnderluingType;
+@:forward(i<caret>)
+abstract AbstractForward(UnderlyingType) from UnderlyingType to UnderlyingType {
+
+  inline public function new(v:UnderlyingType) {
+    this = v;
+  }
+
+}

--- a/testData/completion/references/AbstractForward.txt
+++ b/testData/completion/references/AbstractForward.txt
@@ -1,0 +1,12 @@
+:INCLUDE
+indexOf
+init
+toString
+
+:EXCLUDE
+new
+__init__
+length
+calculate
+isDisposed
+name

--- a/testData/completion/references/AbstractForward1.hx
+++ b/testData/completion/references/AbstractForward1.hx
@@ -1,0 +1,18 @@
+import com.util.UnderlyingType;
+@:forward(init, indexOf)
+abstract AbstractForward1(UnderlyingType) from UnderlyingType to UnderlyingType {
+
+  inline public function new(v:UnderlyingType) {
+    this = v;
+  }
+
+}
+
+class Test {
+
+  public function new() {
+    var a:AbstractForward1 = new UnderlyingType();
+    a.<caret>
+  }
+
+}

--- a/testData/completion/references/AbstractForward1.txt
+++ b/testData/completion/references/AbstractForward1.txt
@@ -1,0 +1,12 @@
+:INCLUDE
+indexOf
+init
+
+:EXCLUDE
+new
+__init__
+length
+toString
+calculate
+isDisposed
+name

--- a/testData/completion/references/AbstractForward2.hx
+++ b/testData/completion/references/AbstractForward2.hx
@@ -1,0 +1,18 @@
+import com.util.UnderlyingType;
+@:forward
+abstract AbstractForward2(UnderlyingType) from UnderlyingType to UnderlyingType {
+
+  inline public function new(v:UnderlyingType) {
+    this = v;
+  }
+
+}
+
+class Test {
+
+  public function new() {
+    var a:AbstractForward1 = new UnderlyingType();
+    a.<caret>
+  }
+
+}

--- a/testData/completion/references/AbstractForward2.txt
+++ b/testData/completion/references/AbstractForward2.txt
@@ -1,0 +1,12 @@
+:INCLUDE
+indexOf
+init
+length
+toString
+
+:EXCLUDE
+new
+__init__
+calculate
+isDisposed
+name

--- a/testData/completion/references/AbstractForward3.hx
+++ b/testData/completion/references/AbstractForward3.hx
@@ -1,0 +1,10 @@
+import com.util.UnderlyingType;
+@:forward
+abstract AbstractForward2(UnderlyingType) from UnderlyingType to UnderlyingType {
+
+  inline public function new(v:UnderlyingType) {
+    this = v;
+    this.<caret>
+  }
+
+}

--- a/testData/completion/references/AbstractForward3.txt
+++ b/testData/completion/references/AbstractForward3.txt
@@ -1,0 +1,12 @@
+:INCLUDE
+indexOf
+init
+length
+toString
+calculate
+isDisposed
+name
+
+:EXCLUDE
+new
+__init__

--- a/testData/completion/references/com/util/UnderlyingType.hx
+++ b/testData/completion/references/com/util/UnderlyingType.hx
@@ -1,0 +1,19 @@
+class UnderlyingType {
+
+  public var length:Int = 0;
+
+  var name:String = "";
+
+  public function new() {}
+
+  public function init() {}
+
+  public function indexOf():Int { return 0; }
+
+  public function toString():String { return "UnderlyingType"; }
+
+  private function calculate() {}
+
+  function isDisposed():Bool { return false; }
+
+}

--- a/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
+++ b/testSrc/com/intellij/plugins/haxe/lang/completion/ReferenceCompletionTest.java
@@ -256,6 +256,22 @@ public class ReferenceCompletionTest extends HaxeCompletionTestBase {
     doTestInclude("com/util/SampleAbstractEnum.hx");
   }
 
+  public void testAbstractForward() throws Throwable {
+    doTestInclude("com/util/UnderlyingType.hx");
+  }
+
+  public void testAbstractForward1() throws Throwable {
+    doTestInclude("com/util/UnderlyingType.hx");
+  }
+
+  public void testAbstractForward2() throws Throwable {
+    doTestInclude("com/util/UnderlyingType.hx");
+  }
+
+  public void testAbstractForward3() throws Throwable {
+    doTestInclude("com/util/UnderlyingType.hx");
+  }
+
   //public void testUsingStringTools() throws Throwable {
   //  myFixture.configureByFiles("UsingStringTools.hx", "std/StringTools.hx", "std/String.hx", "std/StdTypes.hx");
   //  doTestVariantsInner("UsingStringTools.txt");


### PR DESCRIPTION
Fix issues #447 and #108.

- Forwarding abstract fields resolved inside meta @:forward
- Fields autocomplete inside meta @:forward
- Abstract type with forwarding fields resolved
- Abstract type with forwarding fields autocomplete
- Release notes updated