### PR TITLE
Incorrect error annotation in extended class for static fields and methods with same names like in base class. (issue #449)

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -52,6 +52,7 @@
         <li>Incorrect field access modifier after action generate set/get methods. Can't use action generate set/get methods for static fields. (TiVo Issue #442)</li>
         <li>Fix use scope for var declarations (issue #235)</li>
         <li>Find usages import filtering (issue #426)</li>
+        <li>Incorrect error annotation in extended class for static fields and methods with same names like in base class. (issue #449)</li>
       </ul>
       <p>0.9.9: (community release)</p>
       <ul>

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
@@ -137,9 +137,14 @@ class FieldChecker {
       }
       if (fieldDeclaringClass != null) {
         for (HaxeFieldModel parentField : fieldDeclaringClass.getFields()) {
-          if (parentField.getName().equals(field.getName()) && !parentField.isStatic()) {
-            holder.createErrorAnnotation(field.getDeclarationPsi(), "Redefinition of variable '" + field.getName()
-              + "' in subclass is not allowed. Previously declared at '" + fieldDeclaringClass.getName() + "'.");
+          if (parentField.getName().equals(field.getName())) {
+            if (parentField.isStatic()) {
+              holder.createWarningAnnotation(field.getNameOrBasePsi(), "Field '" + field.getName()
+                + "' overrides a static field of a superclass.");
+            } else {
+              holder.createErrorAnnotation(field.getDeclarationPsi(), "Redefinition of variable '" + field.getName()
+                + "' in subclass is not allowed. Previously declared at '" + fieldDeclaringClass.getName() + "'.");
+            }
             break;
           }
         }
@@ -490,32 +495,38 @@ class MethodChecker {
         );
       }
     }
-    else if (parentMethod != null && !parentMethod.isStatic()) {
-      requiredOverride = true;
+    else if (parentMethod != null) {
+      if (parentMethod.isStatic()) {
+        holder.createWarningAnnotation(currentMethod.getNameOrBasePsi(), "Method '" + currentMethod.getName()
+          + "' overrides a static method of a superclass");
+      }
+      else {
+        requiredOverride = true;
 
-      if (parentModifiers.hasAnyModifier(HaxeModifierType.INLINE, HaxeModifierType.STATIC, HaxeModifierType.FINAL)) {
-        Annotation annotation =
-          holder.createErrorAnnotation(currentMethod.getNameOrBasePsi(), "Can't override static, inline or final methods");
-        for (HaxeModifierType mod : new HaxeModifierType[]{HaxeModifierType.FINAL, HaxeModifierType.INLINE, HaxeModifierType.STATIC}) {
-          if (parentModifiers.hasModifier(mod)) {
-            annotation.registerFix(
-              new HaxeModifierRemoveFixer(parentModifiers, mod, "Remove " + mod.s + " from " + parentMethod.getFullName())
-            );
+        if (parentModifiers.hasAnyModifier(HaxeModifierType.INLINE, HaxeModifierType.STATIC, HaxeModifierType.FINAL)) {
+          Annotation annotation =
+            holder.createErrorAnnotation(currentMethod.getNameOrBasePsi(), "Can't override static, inline or final methods");
+          for (HaxeModifierType mod : new HaxeModifierType[]{HaxeModifierType.FINAL, HaxeModifierType.INLINE, HaxeModifierType.STATIC}) {
+            if (parentModifiers.hasModifier(mod)) {
+              annotation.registerFix(
+                new HaxeModifierRemoveFixer(parentModifiers, mod, "Remove " + mod.s + " from " + parentMethod.getFullName())
+              );
+            }
           }
         }
-      }
 
-      if (currentModifiers.getVisibility().hasLowerVisibilityThan(parentModifiers.getVisibility())) {
-        Annotation annotation = holder.createErrorAnnotation(
-          currentMethod.getNameOrBasePsi(),
-          "Field " +
-          currentMethod.getName() +
-          " has less visibility (public/private) than superclass one"
-        );
-        annotation.registerFix(
-          new HaxeModifierReplaceVisibilityFixer(currentModifiers, parentModifiers.getVisibility(), "Change current method visibility"));
-        annotation.registerFix(
-          new HaxeModifierReplaceVisibilityFixer(parentModifiers, currentModifiers.getVisibility(), "Change parent method visibility"));
+        if (currentModifiers.getVisibility().hasLowerVisibilityThan(parentModifiers.getVisibility())) {
+          Annotation annotation = holder.createErrorAnnotation(
+            currentMethod.getNameOrBasePsi(),
+            "Field " +
+            currentMethod.getName() +
+            " has less visibility (public/private) than superclass one"
+          );
+          annotation.registerFix(
+            new HaxeModifierReplaceVisibilityFixer(currentModifiers, parentModifiers.getVisibility(), "Change current method visibility"));
+          annotation.registerFix(
+            new HaxeModifierReplaceVisibilityFixer(parentModifiers, currentModifiers.getVisibility(), "Change parent method visibility"));
+        }
       }
     }
 

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
@@ -137,7 +137,7 @@ class FieldChecker {
       }
       if (fieldDeclaringClass != null) {
         for (HaxeFieldModel parentField : fieldDeclaringClass.getFields()) {
-          if (parentField.getName().equals(field.getName())) {
+          if (parentField.getName().equals(field.getName()) && !parentField.isStatic()) {
             holder.createErrorAnnotation(field.getDeclarationPsi(), "Redefinition of variable '" + field.getName()
               + "' in subclass is not allowed. Previously declared at '" + fieldDeclaringClass.getName() + "'.");
             break;
@@ -490,7 +490,7 @@ class MethodChecker {
         );
       }
     }
-    else if (parentMethod != null) {
+    else if (parentMethod != null && !parentMethod.isStatic()) {
       requiredOverride = true;
 
       if (parentModifiers.hasAnyModifier(HaxeModifierType.INLINE, HaxeModifierType.STATIC, HaxeModifierType.FINAL)) {

--- a/src/common/com/intellij/plugins/haxe/model/HaxeMemberModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeMemberModel.java
@@ -41,6 +41,10 @@ abstract public class HaxeMemberModel {
     return this.getModifiers().hasModifier(HaxeModifierType.PUBLIC);
   }
 
+  public boolean isStatic() {
+    return getModifiers().hasModifier(HaxeModifierType.STATIC);
+  }
+
   private HaxeDocumentModel _document = null;
   @NotNull
   public HaxeDocumentModel getDocument() {

--- a/src/common/com/intellij/plugins/haxe/model/HaxeMethodModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeMethodModel.java
@@ -84,10 +84,6 @@ public class HaxeMethodModel extends HaxeMemberModel {
     return (psi != null) ? psi : getNameOrBasePsi();
   }
 
-  public boolean isStatic() {
-    return getModifiers().hasModifier(HaxeModifierType.STATIC);
-  }
-
   private HaxeClassModel _declaringClass = null;
   public HaxeClassModel getDeclaringClass() {
     if (_declaringClass == null) {

--- a/testData/annotation.semantic/StaticsInExtended.hx
+++ b/testData/annotation.semantic/StaticsInExtended.hx
@@ -1,20 +1,20 @@
 class StaticsInExtended extends BaseClass {
 
-  public static var MY_STATIC_FIELD:String = "test";
+  public static var <warning descr="Field 'MY_STATIC_FIELD' overrides a static field of a superclass.">MY_STATIC_FIELD</warning>:String = "test";
 
-  @:isVar public static var myStaticProperty(get, set):String;
+  @:isVar public static var <warning descr="Field 'myStaticProperty' overrides a static field of a superclass.">myStaticProperty</warning>(get, set):String;
 
-  static function get_myStaticProperty():String {
+  static function <warning descr="Method 'get_myStaticProperty' overrides a static method of a superclass">get_myStaticProperty</warning>():String {
     return myStaticProperty;
   }
 
-  static function set_myStaticProperty(value:String) {
+  static function <warning descr="Method 'set_myStaticProperty' overrides a static method of a superclass">set_myStaticProperty</warning>(value:String) {
     myStaticProperty = value;
   }
 
   public function new() { super(); }
 
-  public static function myStaticMethod() {}
+  public static function <warning descr="Method 'myStaticMethod' overrides a static method of a superclass">myStaticMethod</warning>() {}
 
 }
 

--- a/testData/annotation.semantic/StaticsInExtended.hx
+++ b/testData/annotation.semantic/StaticsInExtended.hx
@@ -1,0 +1,39 @@
+class StaticsInExtended extends BaseClass {
+
+  public static var MY_STATIC_FIELD:String = "test";
+
+  @:isVar public static var myStaticProperty(get, set):String;
+
+  static function get_myStaticProperty():String {
+    return myStaticProperty;
+  }
+
+  static function set_myStaticProperty(value:String) {
+    myStaticProperty = value;
+  }
+
+  public function new() { super(); }
+
+  public static function myStaticMethod() {}
+
+}
+
+class BaseClass {
+
+  public static var MY_STATIC_FIELD:String = "test";
+
+  @:isVar public static var myStaticProperty(get, set):String;
+
+  static function get_myStaticProperty():String {
+    return myStaticProperty;
+  }
+
+  static function set_myStaticProperty(value:String) {
+    myStaticProperty = value;
+  }
+
+  public function new() {}
+
+  public static function myStaticMethod() {}
+
+}

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -194,6 +194,6 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
   }
 
   public void testStaticsInExtended() throws Exception {
-    doTestNoFixWithWarnings();
+    doTestNoFixWithoutWarnings();
   }
 }

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -192,4 +192,8 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
   public void testVariableRedefinition() throws Exception {
     doTestNoFixWithWarnings();
   }
+
+  public void testStaticsInExtended() throws Exception {
+    doTestNoFixWithWarnings();
+  }
 }


### PR DESCRIPTION
Fix issue #449.

- Check is base field with some name as in extended class is not static
- Check is base method with some name as in extended class is not static
- Move isStatic method from HaxeMethodModel to HaxeMemberModel (fields can be static too)
- Release notes updated