### PR TITLE
resolve util getIterable() assert fix

### DIFF
--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -434,7 +434,11 @@ public class HaxeResolveUtil {
     }
     if (element instanceof HaxeForStatement) {
       final HaxeIterable iterable = ((HaxeForStatement)element).getIterable();
-      assert iterable != null;
+      if(iterable == null) {
+        // iterable is @Nullable
+        // (sometimes when you're typing for statement it becames null for short time)
+        return HaxeClassResolveResult.EMPTY;
+      }
       final HaxeExpression expression = iterable.getExpression();
       if (expression instanceof HaxeReference) {
         final HaxeClassResolveResult resolveResult = ((HaxeReference)expression).resolveHaxeClass();


### PR DESCRIPTION
getIterable() sometimes became null while you're typing for statement
this is OK, while getIterable() method is @Nullable

- assert statement has been removed and fallback to EMPTY result.
- previously assert hangs up IDEA sometimes

TESTS: it's difficult to write unit test for that in short time, i can't reproduce it until bad for statement is not for statement and it was reproduced a couple of times on the real complex project while typing for statement.