### PR TITLE
Highlight 'in' as keyword when it appears in a for statement.

### DIFF
--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeColorAnnotator.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeColorAnnotator.java
@@ -111,7 +111,12 @@ public class HaxeColorAnnotator implements Annotator {
     PsiElement parent = element != null ? element.getParent() : null;
 
     if (element instanceof PsiJavaToken) {
-      isKeyword = parent instanceof HaxeForStatement && "in".equals(element.getText());
+      if (parent instanceof HaxeForStatement) {
+        isKeyword = "in".equals(element.getText());
+      } else if (parent instanceof HaxeImportStatementWithInSupport) {
+        String elementText = element.getText();
+        isKeyword = "in".equals(elementText) || "as".equals(elementText);
+      }
     }
     else if (element instanceof HaxeIdentifier) {
       if (parent instanceof HaxeAbstractClassDeclaration) {


### PR DESCRIPTION
( Issue #501)

OK.  I started by trying to answer the question of why this wasn't working and where it had to be fixed.  I ended with the fix.  

However, I also spent quite a bit of time trying to make a unit test for this and have failed.  There are no other color tests that I can find (even on other projects).  The existing annotation tests for the plugin expect and check for error annotations and don't work for coloring (well... the ones I tried to write all work when they should be failing).