### PR TITLE
Update for Hxcpp 3.3 compiler output. (Fixes #514)

### DIFF
--- a/common/src/com/intellij/plugins/haxe/compilation/HaxeCompilerError.java
+++ b/common/src/com/intellij/plugins/haxe/compilation/HaxeCompilerError.java
@@ -79,11 +79,11 @@ public class HaxeCompilerError {
     {
         Matcher m;
 
-        // Error: Library ([^\w]+) is not installed(.*)
+        // Library (\S+) (is not installed.*)
         if ((m = pLibraryNotInstalled.matcher(message)).matches()) {
-            return new HaxeCompilerError(CompilerMessageCategory.WARNING,
+            return new HaxeCompilerError(CompilerMessageCategory.ERROR,
                                          "Library " + m.group(1).trim() +
-                                         "is not installed " +
+                                         " " +
                                          m.group(2).trim(), "", -1, -1);
         }
 
@@ -196,7 +196,7 @@ public class HaxeCompilerError {
     }
 
     static Pattern pLibraryNotInstalled = Pattern.compile
-        ("Error: Library ([\\S]+) is not installed(.*)");
+        ("Library (\\S+) (is not installed.*)");
     static Pattern pBareError = Pattern.compile("([^:]*)Error:(.*)", Pattern.CASE_INSENSITIVE);
     static Pattern pColumnError =
         Pattern.compile("(.+?):([\\d]+): characters ([\\d]+)-[\\d]+ :(.*)");
@@ -212,7 +212,10 @@ public class HaxeCompilerError {
     // as errors.  Keeping this up to date will always be an arms race.
     static HashSet<String> mInformationalMessages = new HashSet<String>();
     static {
-      String[] nonErrors = { "Defines", "Classpath", "Classes found", "Display file", "Using default windows compiler" };
+      String[] nonErrors = { "Defines", "Classpath", "Classes found", "Display file", "Using default windows compiler",
+        // Hxcpp 3.3 message lines:
+        "- Compile", "-  - Link",
+      };
       mInformationalMessages.addAll(Arrays.asList(nonErrors));
     }
     static Pattern pGeneratingStatusMessage = Pattern.compile("Generating (.+)");

--- a/testSrc/com/intellij/plugins/haxe/compiler/HaxeCompilerErrorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/compiler/HaxeCompilerErrorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Written by Eric Bishton.  No copyright is asserted for this file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.compiler;
+
+import com.intellij.openapi.compiler.CompilerMessageCategory;
+import com.intellij.plugins.haxe.compilation.HaxeCompilerError;
+import com.intellij.testFramework.UsefulTestCase;
+
+/**
+ * Created by ebishton on 10/29/16.
+ */
+public class HaxeCompilerErrorTest extends UsefulTestCase {
+
+  private void doTest(String output, CompilerMessageCategory cat, String msg, String path, int line, int col) throws Throwable {
+    HaxeCompilerError e = HaxeCompilerError.create("", output);
+    assertEquals(cat, e.getCategory());
+    assertEquals(msg, e.getErrorMessage());
+    assertEquals(path, e.getPath());
+    assertEquals(line, e.getLine());
+    assertEquals(col, e.getColumn());
+  }
+
+  private void doInfoTest(String compilerOutput) throws Throwable {
+    doTest(compilerOutput, CompilerMessageCategory.INFORMATION, compilerOutput.trim(), "", -1, -1);
+  }
+
+  private void doWarningTest(String compilerOutput) throws Throwable {
+    doTest(compilerOutput, CompilerMessageCategory.WARNING, compilerOutput.trim(), "", -1, -1);
+  }
+
+  private void doErrorTest(String compilerOutput, String expected) throws Throwable {
+    doTest(compilerOutput, CompilerMessageCategory.ERROR, expected, "", -1, -1);
+  }
+
+  // hxcpp 3.3 link message
+  public void testLinkMessage() throws Throwable {
+    doInfoTest(" -  - Link : ApplicationMain: xcrun");
+  }
+
+  // hxcpp 3.3 compile message.
+  public void testCompileMessage() throws Throwable {
+    doInfoTest(" - Compile : src/ApplicationMain.hx");
+  }
+
+  public void testCompilingMessage() throws Throwable {
+    doInfoTest(" - Compiling src/ApplicationMain.hx : <some_message>");
+  }
+
+  public void testGeneratingMessage() throws Throwable {
+    doInfoTest("Generating out/ApplicationMain.cpp : <some_message>");
+  }
+
+  public void testLibraryNotInstalled() throws Throwable {
+    String compilerOutput = "Error: Library Flixel is not installed. Please run haxelib...";
+    doTest(compilerOutput, CompilerMessageCategory.ERROR, "Library Flixel is not installed. Please run haxelib...", "", -1, -1);
+  }
+
+  // Hxcpp 3.3
+  public void testLibraryNotInstalledHxcpp() throws Throwable {
+    String compilerOutput = "Library hxcpp is not installed";
+    doErrorTest(compilerOutput, compilerOutput);
+  }
+
+  public void testGenericError() throws Throwable {
+    String compilerOutput = "Unknown Error : This is an error message.";
+    String expected = " (Unknown Error) This is an error message.";
+    doErrorTest(compilerOutput, expected);
+  }
+
+  public void testLinesError() throws Throwable {
+    String compilerOutput = "Test.hx:4: lines 4-10 : Invalid -main : Test does not have static function main";
+    doTest(compilerOutput, CompilerMessageCategory.ERROR, "Invalid -main : Test does not have static function main", "Missing file: /Test.hx", 4, -1);
+  }
+
+  public void testHxcppBuildFailure() throws Throwable {
+    String compilerOutput = "Error: Build failed";
+    String expected = "Build failed";
+    doErrorTest(compilerOutput, expected);
+  }
+
+  public void testUnexpectedCharacter() throws Throwable {
+    String compilerOutput = "Test.hx:4: characters 6-7 : Unexpected %";
+    String expected = "Unexpected %";
+    doTest(compilerOutput, CompilerMessageCategory.ERROR, expected, "Missing file: /Test.hx", 4, 6);
+  }
+
+}


### PR DESCRIPTION
Adds new regular expressions to the compiler output checking.  Adds unit tests.
