### PR TITLE
Formatter: Prevent excess linefeed between doctype and function

### DIFF
--- a/src/common/com/intellij/plugins/haxe/ide/formatter/HaxeSpacingProcessor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/formatter/HaxeSpacingProcessor.java
@@ -75,7 +75,7 @@ public class HaxeSpacingProcessor {
       return Spacing.createSpacing(0, 0, 1, false, mySettings.KEEP_BLANK_LINES_IN_CODE);
     }
 
-    if (type2 == FUNCTION_DECLARATION_WITH_ATTRIBUTES) {
+    if (type2 == FUNCTION_DECLARATION_WITH_ATTRIBUTES && !ONLY_COMMENTS.contains(type1)) { // prevent excess linefeed between doctype and function
       return Spacing.createSpacing(0, 0, 2, false, mySettings.KEEP_BLANK_LINES_IN_CODE);
     }
 

--- a/testData/formatter/LineFeedsWithComments.hx
+++ b/testData/formatter/LineFeedsWithComments.hx
@@ -1,0 +1,22 @@
+class Test {
+    public function foo():Int return 0;
+
+    // MSL_COMMENT
+    public function single() {
+    }
+
+    /*
+    MML_COMMENT
+     */
+    public function multiline() {
+    }
+
+    /**
+    DOC_COMMENT
+    */
+    public function javadoc() {
+    }
+
+    // a variable
+    var v:Int;
+}

--- a/testData/formatter/LineFeedsWithComments.txt
+++ b/testData/formatter/LineFeedsWithComments.txt
@@ -1,0 +1,22 @@
+class Test {
+    public function foo():Int return 0;
+
+    // MSL_COMMENT
+    public function single() {
+    }
+
+    /*
+    MML_COMMENT
+     */
+    public function multiline() {
+    }
+
+    /**
+    DOC_COMMENT
+    */
+    public function javadoc() {
+    }
+
+    // a variable
+    var v:Int;
+}

--- a/testSrc/com/intellij/plugins/haxe/lang/HaxeFormatterTest.java
+++ b/testSrc/com/intellij/plugins/haxe/lang/HaxeFormatterTest.java
@@ -238,4 +238,8 @@ public class HaxeFormatterTest extends HaxeCodeInsightFixtureTestCase {
     myTestStyleSettings.KEEP_FIRST_COLUMN_COMMENT = true;
     doTest();
   }
+
+  public void testLineFeedsWithComments() throws Exception {
+    doTest();
+  }
 }


### PR DESCRIPTION
A small changes to formatter fixing annoying linefeed between function and its doctype/comment.

For example, before this patch a code
```haxe
class Test {
    public function foo():Int return 0;

    // MSL_COMMENT
    public function single() {
    }

    /*
    MML_COMMENT
     */
    public function multiline() {
    }

    /**
    DOC_COMMENT
    */
    public function javadoc() {
    }

    // a variable
    var v:Int;
}
```
will be reformatted to
```haxe
class Test {
    public function foo():Int return 0;

    // MSL_COMMENT

    public function single() {
    }

    /*
    MML_COMMENT
     */

    public function multiline() {
    }

    /**
    DOC_COMMENT
    */
  
    public function javadoc() {
    }

    // a variable
    var v:Int;
}
```
(consider floating comments).